### PR TITLE
Color format hotfix

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -28,7 +28,7 @@ use text::Font;
 use texture::Texture;
 
 /// The format of the back buffer color requested from the windowing system.
-pub type ColorFormat = gfx::format::Srgba8;
+pub type ColorFormat = gfx::format::Rgba8;
 /// The format of the depth stencil buffer requested from the windowing system.
 pub type DepthFormat = gfx::format::DepthStencil;
 pub type ShadowFormat = gfx::format::Depth32F;


### PR DESCRIPTION
Closes #104 
Doesn't affect anything due to bug in gfx, but this hotfix should be replaced with appropriate off-screen render target (see #109)

The reason I pushed this is that I can't work on `three-rs` because of this bug.