### PR TITLE
Use layout(std140)

### DIFF
--- a/data/shaders/globals.glsl
+++ b/data/shaders/globals.glsl
@@ -1,4 +1,4 @@
-uniform b_Globals {
+layout(std140) uniform b_Globals {
     mat4 u_ViewProj;
     mat4 u_InverseProj;
     mat4 u_View;

--- a/data/shaders/lights.glsl
+++ b/data/shaders/lights.glsl
@@ -11,6 +11,6 @@ struct Light {
     ivec4 shadow_params;
 };
 
-uniform b_Lights {
+layout(std140) uniform b_Lights {
     Light u_Lights[MAX_LIGHTS];
 };

--- a/data/shaders/pbr_ps.glsl
+++ b/data/shaders/pbr_ps.glsl
@@ -35,7 +35,7 @@ uniform sampler2D u_EmissiveSampler;
 uniform sampler2D u_MetallicRoughnessSampler;
 uniform sampler2D u_OcclusionSampler;
 
-uniform b_PbrParams {
+layout(std140) uniform b_PbrParams {
     vec4 u_BaseColorFactor;
     vec3 u_Camera;
     vec3 u_EmissiveFactor;

--- a/data/shaders/quad_vs.glsl
+++ b/data/shaders/quad_vs.glsl
@@ -2,7 +2,7 @@
 
 out vec2 v_TexCoord;
 
-uniform b_Params {
+layout(std140) uniform b_Params {
     vec4 u_Rect;
     float u_Depth;
 };


### PR DESCRIPTION
This PR adds standardises the layout of uniform blocks with `layout(std140)` to prevent hardware-dependent data alignment/padding issues. Fixes https://github.com/three-rs/three/issues/93.