### PR TITLE
Add examples in geometry documentation

### DIFF
--- a/examples/aviator/main.rs
+++ b/examples/aviator/main.rs
@@ -61,9 +61,11 @@ fn main() {
     win.scene.add(&sky.group);
 
     let mut airplane = plane::AirPlane::new(&mut win.factory);
-    airplane
-        .group
-        .set_transform([0.0, 100.0, 0.0], [0.0, 0.0, 0.0, 1.0], 0.25);
+    airplane.group.set_transform(
+        [0.0, 100.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+        0.25,
+    );
     win.scene.add(&airplane.group);
 
     let timer = win.input.time();

--- a/examples/aviator/plane.rs
+++ b/examples/aviator/plane.rs
@@ -104,7 +104,12 @@ impl AirPlane {
     ) {
         let q = Quaternion::from_angle_x(Rad(0.3 * time));
         self.propeller_group.set_orientation(q);
-        self.group
-            .set_position([0.0 + target.x * 100.0, 100.0 + target.y * 75.0, 0.0]);
+        self.group.set_position(
+            [
+                0.0 + target.x * 100.0,
+                100.0 + target.y * 75.0,
+                0.0,
+            ],
+        );
     }
 }

--- a/examples/lights.rs
+++ b/examples/lights.rs
@@ -15,8 +15,12 @@ fn main() {
     let mut dir_light = win.factory.directional_light(0xffffff, 0.9);
     dir_light.look_at([15.0, 35.0, 35.0], [0.0, 0.0, 2.0], None);
     let shadow_map = win.factory.shadow_map(1024, 1024);
-    let _debug_shadow = win.renderer
-        .debug_shadow_quad(&shadow_map, 1, [10, 10], [256, 256]);
+    let _debug_shadow = win.renderer.debug_shadow_quad(
+        &shadow_map,
+        1,
+        [10, 10],
+        [256, 256],
+    );
     dir_light.set_shadow(shadow_map, 40.0, 1.0 .. 200.0);
 
     let mut lights: [&mut three::Object; 4] = [

--- a/examples/lights.rs
+++ b/examples/lights.rs
@@ -31,7 +31,7 @@ fn main() {
     }
 
     let mut sphere = {
-        let geometry = three::Geometry::sphere(3.0, 20, 20);
+        let geometry = three::Geometry::uv_sphere(3.0, 20, 20);
         let material = three::Material::MeshPhong {
             color: 0xffA0A0,
             glossiness: 80.0,

--- a/examples/shapes.rs
+++ b/examples/shapes.rs
@@ -36,7 +36,7 @@ fn main() {
     win.scene.add(&mcyl);
 
     let mut msphere = {
-        let geometry = three::Geometry::sphere(2.0, 5, 5);
+        let geometry = three::Geometry::uv_sphere(2.0, 5, 5);
         let material = three::Material::MeshBasic {
             color: 0xff0000,
             map: None,

--- a/examples/sprite.rs
+++ b/examples/sprite.rs
@@ -45,14 +45,15 @@ fn main() {
     let shaders_path: String = format!("{}/data/shaders", env!("CARGO_MANIFEST_DIR"));
     let shaders_path_str: &str = shaders_path.as_str();
     let mut win = three::Window::builder("Three-rs sprite example", shaders_path_str).build();
-    let cam = win.factory
-        .orthographic_camera([0.0, 0.0], 10.0, -10.0 .. 10.0);
+    let cam = win.factory.orthographic_camera(
+        [0.0, 0.0],
+        10.0,
+        -10.0 .. 10.0,
+    );
 
     let pikachu_path: String = format!("{}/test_data/pikachu_anim.png", env!("CARGO_MANIFEST_DIR"));
     let pikachu_path_str: &str = pikachu_path.as_str();
-    let material = three::Material::Sprite {
-        map: win.factory.load_texture(pikachu_path_str),
-    };
+    let material = three::Material::Sprite { map: win.factory.load_texture(pikachu_path_str) };
     let mut sprite = win.factory.sprite(material);
     sprite.set_scale(8.0);
     win.scene.add(&sprite);
@@ -75,15 +76,15 @@ fn main() {
     }
 
     while win.update() && !three::KEY_ESCAPE.is_hit(&win.input) {
-        let row = three::AXIS_LEFT_RIGHT
-            .delta_hits(&win.input)
-            .map(|mut diff| {
+        let row = three::AXIS_LEFT_RIGHT.delta_hits(&win.input).map(
+            |mut diff| {
                 let total = anim.cell_counts[1] as i8;
                 while diff < 0 {
                     diff += total
                 }
                 (anim.current[1] + diff as u16) % total as u16
-            });
+            },
+        );
         anim.update(row, &win.input);
 
         win.render(&cam);

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -100,9 +100,7 @@ impl AudioData {
             panic!("Can't get default audio endpoint, can't play sound");
         };
         let sink = r::Sink::new(&endpoint);
-        AudioData {
-            source: SourceInternal::D2(sink),
-        }
+        AudioData { source: SourceInternal::D2(sink) }
     }
 }
 

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -167,12 +167,14 @@ impl Perspective {
         aspect_ratio: f32,
     ) -> mint::ColumnMatrix4<f32> {
         match self.zrange {
-            ZRange::Finite(ref range) => cgmath::perspective(
-                cgmath::Deg(self.fov_y),
-                aspect_ratio,
-                range.start,
-                range.end,
-            ).into(),
+            ZRange::Finite(ref range) => {
+                cgmath::perspective(
+                    cgmath::Deg(self.fov_y),
+                    aspect_ratio,
+                    range.start,
+                    range.end,
+                ).into()
+            }
             ZRange::Infinite(ref range) => {
                 let m00 = 1.0 / (aspect_ratio * f32::tan(0.5 * self.fov_y));
                 let m11 = 1.0 / f32::tan(0.5 * self.fov_y);

--- a/src/controls/first_person.rs
+++ b/src/controls/first_person.rs
@@ -107,7 +107,7 @@ impl Builder {
         self.pitch_range = range;
         self
     }
-    
+
     /// Set the initial position.
     ///
     /// Defaults to the world origin.
@@ -355,27 +355,27 @@ impl FirstPerson {
             }
         }
 
-        self.axes
-            .vertical
-            .map(|a| if let Some(time) = a.timed(input) {
+        self.axes.vertical.map(
+            |a| if let Some(time) = a.timed(input) {
                 self.position.y += self.move_speed * time;
-            });
+            },
+        );
 
-        self.axes
-            .forward
-            .map(|a| if let Some(time) = a.timed(input) {
+        self.axes.forward.map(
+            |a| if let Some(time) = a.timed(input) {
                 self.position.x += self.move_speed * time * self.yaw.sin();
                 self.position.z -= self.move_speed * time * self.yaw.cos();
                 if self.vertical_move {
                     self.position.y -= self.move_speed * time * self.pitch.sin();
                 }
-            });
-        self.axes
-            .strafing
-            .map(|a| if let Some(time) = a.timed(input) {
+            },
+        );
+        self.axes.strafing.map(
+            |a| if let Some(time) = a.timed(input) {
                 self.position.x += self.move_speed * time * self.yaw.cos();
                 self.position.z += self.move_speed * time * self.yaw.sin();
-            });
+            },
+        );
 
         let yrot = cgmath::Quaternion::from_angle_y(cgmath::Rad(-self.yaw));
         let xrot = cgmath::Quaternion::from_angle_x(cgmath::Rad(-self.pitch));

--- a/src/factory/load_gltf.rs
+++ b/src/factory/load_gltf.rs
@@ -60,7 +60,8 @@ impl super::Factory {
         // gfx does not support separate min / mag
         // filters yet, so for now we'll use `mag_filter` for both.
         let mag_filter = match params.mag_filter() {
-            None | Some(MagFilter::Nearest) => FilterMethod::Scale,
+            None |
+            Some(MagFilter::Nearest) => FilterMethod::Scale,
             Some(MagFilter::Linear) => FilterMethod::Bilinear,
         };
         let wrap_s = match params.wrap_s() {
@@ -86,8 +87,9 @@ impl super::Factory {
     ) -> Material {
         let pbr = mat.pbr_metallic_roughness();
         let mut is_basic_material = true;
-        let base_color_map = pbr.base_color_texture()
-            .map(|t| self.load_gltf_texture(&t, buffers, base));
+        let base_color_map = pbr.base_color_texture().map(|t| {
+            self.load_gltf_texture(&t, buffers, base)
+        });
         let normal_map = mat.normal_texture().map(|t| {
             is_basic_material = false;
             self.load_gltf_texture(&t, buffers, base)

--- a/src/factory/mod.rs
+++ b/src/factory/mod.rs
@@ -174,12 +174,9 @@ impl Factory {
         let normal_iter = if shape.normals.is_empty() {
             Either::Left(iter::repeat(NORMAL_Z))
         } else {
-            Either::Right(
-                shape
-                    .normals
-                    .iter()
-                    .map(|n| [f2i(n.x), f2i(n.y), f2i(n.z), I8Norm(0)]),
-            )
+            Either::Right(shape.normals.iter().map(|n| {
+                [f2i(n.x), f2i(n.y), f2i(n.z), I8Norm(0)]
+            }))
         };
         let uv_iter = if shape.tex_coords.is_empty() {
             Either::Left(iter::repeat([0.0, 0.0]))
@@ -192,12 +189,9 @@ impl Factory {
             // (Use mikktspace algorithm or otherwise.)
             Either::Left(iter::repeat(TANGENT_X))
         } else {
-            Either::Right(
-                shape
-                    .tangents
-                    .iter()
-                    .map(|t| [f2i(t.x), f2i(t.y), f2i(t.z), f2i(t.w)]),
-            )
+            Either::Right(shape.tangents.iter().map(|t| {
+                [f2i(t.x), f2i(t.y), f2i(t.z), f2i(t.w)]
+            }))
         };
         izip!(position_iter, normal_iter, tangent_iter, uv_iter)
             .map(|(position, normal, tangent, tex_coord)| {
@@ -223,8 +217,10 @@ impl Factory {
             self.backend.create_vertex_buffer_with_slice(&vertices, ())
         } else {
             let faces: &[u32] = gfx::memory::cast_slice(&geometry.faces);
-            self.backend
-                .create_vertex_buffer_with_slice(&vertices, faces)
+            self.backend.create_vertex_buffer_with_slice(
+                &vertices,
+                faces,
+            )
         };
         Mesh {
             object: self.hub.lock().unwrap().spawn_visual(
@@ -303,9 +299,7 @@ impl Factory {
             SubNode::Visual(ref mat, _) => mat.clone(),
             _ => unreachable!(),
         });
-        Mesh {
-            object: hub.spawn_visual(mat, gpu_data),
-        }
+        Mesh { object: hub.spawn_visual(mat, gpu_data) }
     }
 
     /// Create new sprite from `Material`.
@@ -362,9 +356,7 @@ impl Factory {
         Hemisphere::new(self.hub.lock().unwrap().spawn_light(LightData {
             color: sky_color,
             intensity,
-            sub_light: SubLight::Hemisphere {
-                ground: ground_color,
-            },
+            sub_light: SubLight::Hemisphere { ground: ground_color },
             shadow: None,
         }))
     }
@@ -639,25 +631,22 @@ impl Factory {
         obj_dir: Option<&Path>,
     ) -> Material {
         let cf2u = |c: [f32; 3]| {
-            c.iter()
-                .fold(0, |u, &v| (u << 8) + cmp::min((v * 255.0) as u32, 0xFF))
+            c.iter().fold(0, |u, &v| {
+                (u << 8) + cmp::min((v * 255.0) as u32, 0xFF)
+            })
         };
         match *mat {
             obj::Material {
                 kd: Some(color),
                 ns: Some(glossiness),
                 ..
-            } if has_normals =>
-            {
+            } if has_normals => {
                 Material::MeshPhong {
                     color: cf2u(color),
                     glossiness,
                 }
             }
-            obj::Material {
-                kd: Some(color), ..
-            } if has_normals =>
-            {
+            obj::Material { kd: Some(color), .. } if has_normals => {
                 Material::MeshLambert {
                     color: cf2u(color),
                     flat: false,
@@ -772,14 +761,9 @@ impl Factory {
                     });
 
                     indices.clear();
-                    indices.extend(
-                        gr.indices
-                            .iter()
-                            .cloned()
-                            .triangulate()
-                            .vertices()
-                            .map(|tuple| lru.index(tuple) as u16),
-                    );
+                    indices.extend(gr.indices.iter().cloned().triangulate().vertices().map(
+                        |tuple| lru.index(tuple) as u16,
+                    ));
                 };
 
                 info!(
@@ -798,8 +782,10 @@ impl Factory {
                 };
                 info!("\t{:?}", material);
 
-                let (vbuf, slice) = self.backend
-                    .create_vertex_buffer_with_slice(&vertices, &indices[..]);
+                let (vbuf, slice) = self.backend.create_vertex_buffer_with_slice(
+                    &vertices,
+                    &indices[..],
+                );
                 let cbuf = self.backend.create_constant_buffer(1);
                 let mesh = Mesh {
                     object: hub.spawn_visual(

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -6,7 +6,7 @@ use mint;
 use std::collections::HashMap;
 
 /// A shape of geometry that is used for mesh blending.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Shape {
     /// Vertices.
     pub vertices: Vec<mint::Point3<f32>>,
@@ -19,20 +19,50 @@ pub struct Shape {
 }
 
 impl Shape {
-    /// Create an empty shape.
+    /// Creates an empty shape.
     pub fn empty() -> Self {
-        Shape {
-            vertices: Vec::new(),
-            normals: Vec::new(),
-            tangents: Vec::new(),
-            tex_coords: Vec::new(),
-        }
+        Default::default()
     }
 }
 
 /// A collection of vertices, their normals, and faces that defines the
 /// shape of a polyhedral object.
-#[derive(Clone, Debug)]
+///
+/// # Examples
+///
+/// Tetrahedron of unit height and base radius.
+///
+/// ```rust
+/// # extern crate three;
+/// # fn make_tetrahedron() -> three::Geometry {
+/// use std::f32::consts::PI;
+///
+/// let vertices = vec![
+///     [0.0, 1.0, 0.0].into(),
+///     [0.0, 0.0, 1.0].into(),
+///     [(2.0 * PI / 3.0).sin(), 0.0, (2.0 * PI / 3.0).cos()].into(),
+///     [(4.0 * PI / 3.0).sin(), 0.0, (4.0 * PI / 3.0).cos()].into(),
+/// ];
+///
+/// let faces = vec![
+///     [0, 1, 2],
+///     [0, 2, 3],
+///     [0, 3, 1],
+///     [1, 3, 2],
+/// ];
+///
+/// three::Geometry {
+///     faces,
+///     base_shape: three::geometry::Shape {
+///         vertices,
+///         .. three::geometry::Shape::empty()
+///     },
+///     .. three::Geometry::empty()
+/// }
+/// # }
+/// # fn main() { let _ = make_tetrahedron(); }
+/// ```
+#[derive(Clone, Debug, Default)]
 pub struct Geometry {
     /// The original shape of geometry.
     pub base_shape: Shape,
@@ -43,16 +73,57 @@ pub struct Geometry {
 }
 
 impl Geometry {
-    /// Create new `Geometry` without any data in it.
+    /// Create empty `Geometry`.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage.
+    ///
+    /// ```rust
+    /// let geometry = three::Geometry::empty();
+    /// assert!(geometry.base_shape.vertices.is_empty());
+    /// assert!(geometry.shapes.is_empty());
+    /// assert!(geometry.faces.is_empty());
+    /// ```
+    ///
+    /// Completing geometry for a triangle.
+    ///
+    /// ```rust
+    /// # extern crate three;
+    /// fn make_triangle() -> three::Geometry {
+    ///    let vertices = vec![
+    ///        [-0.5, -0.5, 0.0].into(),
+    ///        [ 0.5, -0.5, 0.0].into(),
+    ///        [ 0.5, -0.5, 0.0].into(),
+    ///    ];
+    ///    three::Geometry {
+    ///        base_shape: three::geometry::Shape {
+    ///            vertices,
+    ///            .. three::geometry::Shape::empty()
+    ///        },
+    ///        .. three::Geometry::empty()
+    ///    }
+    /// }
+    /// # fn main() { let _ = make_triangle(); }
+    /// ```
     pub fn empty() -> Self {
-        Geometry {
-            base_shape: Shape::empty(),
-            shapes: HashMap::new(),
-            faces: Vec::new(),
-        }
+        Default::default()
     }
 
     /// Create `Geometry` from vector of vertices.
+    ///
+    /// # Examples
+    ///
+    /// Triangle in the XY plane.
+    ///
+    /// ```rust
+    /// let vertices = vec![
+    ///     [-0.5, -0.5, 0.0].into(),
+    ///     [ 0.5, -0.5, 0.0].into(),
+    ///     [ 0.5, -0.5, 0.0].into(),
+    /// ];
+    /// let geometry = three::Geometry::with_vertices(vertices);
+    /// ```
     pub fn with_vertices(vertices: Vec<mint::Point3<f32>>) -> Self {
         Geometry {
             base_shape: Shape {
@@ -91,33 +162,77 @@ impl Geometry {
         }
     }
 
-    /// Create new Plane with desired size.
-    pub fn plane(
-        sx: f32,
-        sy: f32,
-    ) -> Self {
+    /// Creates planar geometry in the XY plane.
+    ///
+    /// The `width` and `height` parameters specify the total length of the
+    /// geometry along the X and Y axes respectively.
+    ///
+    /// # Examples
+    ///
+    /// Unit square in the XY plane, centered at the origin.
+    ///
+    /// ```rust
+    /// # extern crate three;
+    /// fn make_square() -> three::Geometry {
+    ///     three::Geometry::plane(1.0, 1.0)
+    /// }
+    /// # fn main() { let _ = make_square(); }
+    /// ```
+    pub fn plane(width: f32, height: f32) -> Self {
         Self::generate(
             generators::Plane::new(),
-            |GenVertex { pos, .. }| [pos[0] * 0.5 * sx, pos[1] * 0.5 * sy, 0.0].into(),
+            |GenVertex { pos, .. }| [pos[0] * 0.5 * width, pos[1] * 0.5 * height, 0.0].into(),
             |v| v.normal.into(),
         )
     }
 
-    /// Create new Box with desired size.
-    pub fn cuboid(
-        sx: f32,
-        sy: f32,
-        sz: f32,
-    ) -> Self {
+    /// Creates cuboidal geometry.
+    ///
+    /// The `width`, `height`, and `depth` parameters specify the total length of
+    /// the geometry along the X, Y, and Z axes respectively.
+    ///
+    /// # Examples
+    ///
+    /// Unit cube, centered at the origin.
+    ///
+    /// ```rust
+    /// # extern crate three;
+    /// fn make_cube() -> three::Geometry {
+    ///     three::Geometry::cuboid(1.0, 1.0, 1.0)
+    /// }
+    /// # fn main() { let _ = make_cube(); }
+    /// ```
+    pub fn cuboid(width: f32, height: f32, depth: f32) -> Self {
         Self::generate(
             generators::Cube::new(),
-            |GenVertex { pos, .. }| [pos[0] * 0.5 * sx, pos[1] * 0.5 * sy, pos[2] * 0.5 * sz].into(),
+            |GenVertex { pos, .. }| [pos[0] * 0.5 * width, pos[1] * 0.5 * height, pos[2] * 0.5 * depth].into(),
             |v| v.normal.into(),
         )
     }
 
-    /// Create new Cylinder or Cone with desired top and bottom radius, height
-    /// and number of segments.
+    /// Creates cylindrial geometry.
+    ///
+    /// # Examples
+    ///
+    /// Cylinder of unit height and radius, using 12 segments at each end.
+    ///
+    /// ```rust
+    /// # extern crate three;
+    /// fn make_cylinder() -> three::Geometry {
+    ///     three::Geometry::cylinder(1.0, 1.0, 1.0, 12)
+    /// }
+    /// # fn main() { let _ = make_cylinder(); }
+    /// ```
+    ///
+    /// Cone of unit height and unit radius at the bottom.
+    ///
+    /// ```rust
+    /// # extern crate three;
+    /// fn make_cone() -> three::Geometry {
+    ///     three::Geometry::cylinder(0.0, 1.0, 1.0, 12)
+    /// }
+    /// # fn main() { let _ = make_cone(); }
+    /// ```
     pub fn cylinder(
         radius_top: f32,
         radius_bottom: f32,
@@ -135,14 +250,27 @@ impl Geometry {
         )
     }
 
-    /// Create new Sphere with desired radius and number of segments.
-    pub fn sphere(
+    /// Creates geometry for a sphere, using the UV method.
+    ///
+    /// * `equatorial_divisions` specifies the number of segments about
+    ///    the sphere equator that lies in the XZ plane.
+    /// * `meridional_segments` specifies the number of segments around
+    ///    the sphere meridian that lies in the YZ plane.
+    ///
+    /// ```rust
+    /// # extern crate three;
+    /// fn make_sphere() -> three::Geometry {
+    ///     three::Geometry::uv_sphere(1.0, 12, 12)
+    /// }
+    /// # fn main() { let _ = make_sphere(); }
+    /// ```
+    pub fn uv_sphere(
         radius: f32,
-        width_segments: usize,
-        height_segments: usize,
+        equatorial_segments: usize,
+        meridional_segments: usize,
     ) -> Self {
         Self::generate(
-            generators::SphereUV::new(width_segments, height_segments),
+            generators::SphereUV::new(equatorial_segments, meridional_segments),
             |GenVertex { pos, .. }| [pos[0] * radius, pos[1] * radius, pos[2] * radius].into(),
             |v| v.normal.into(),
         )

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -178,7 +178,10 @@ impl Geometry {
     /// }
     /// # fn main() { let _ = make_square(); }
     /// ```
-    pub fn plane(width: f32, height: f32) -> Self {
+    pub fn plane(
+        width: f32,
+        height: f32,
+    ) -> Self {
         Self::generate(
             generators::Plane::new(),
             |GenVertex { pos, .. }| [pos[0] * 0.5 * width, pos[1] * 0.5 * height, 0.0].into(),
@@ -202,10 +205,20 @@ impl Geometry {
     /// }
     /// # fn main() { let _ = make_cube(); }
     /// ```
-    pub fn cuboid(width: f32, height: f32, depth: f32) -> Self {
+    pub fn cuboid(
+        width: f32,
+        height: f32,
+        depth: f32,
+    ) -> Self {
         Self::generate(
             generators::Cube::new(),
-            |GenVertex { pos, .. }| [pos[0] * 0.5 * width, pos[1] * 0.5 * height, pos[2] * 0.5 * depth].into(),
+            |GenVertex { pos, .. }| {
+                [
+                    pos[0] * 0.5 * width,
+                    pos[1] * 0.5 * height,
+                    pos[2] * 0.5 * depth,
+                ].into()
+            },
             |v| v.normal.into(),
         )
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -70,9 +70,7 @@ impl Input {
 
     /// Create new timer.
     pub fn time(&self) -> Timer {
-        Timer {
-            start: self.0.time_moment,
-        }
+        Timer { start: self.0.time_moment }
     }
 
     /// Get current delta time (time since previous frame) in seconds.
@@ -179,9 +177,9 @@ impl Input {
         pos_ndc: mint::Point2<f32>,
     ) {
         use cgmath::Point2;
-        self.1
-            .mouse_moves
-            .push((Point2::from(pos) - Point2::from(self.0.mouse_pos)).into());
+        self.1.mouse_moves.push(
+            (Point2::from(pos) - Point2::from(self.0.mouse_pos)).into(),
+        );
         self.1.mouse_moves_ndc.push(
             (Point2::from(pos_ndc) - Point2::from(self.0.mouse_pos_ndc)).into(),
         );
@@ -252,20 +250,24 @@ impl Button {
     ) -> u8 {
         use std::u8::MAX;
         match *self {
-            Button::Key(button) => input
-                .1
-                .keys_hit
-                .iter()
-                .filter(|&&key| key == button)
-                .take(MAX as usize)
-                .count() as u8,
-            Button::Mouse(button) => input
-                .1
-                .mouse_hit
-                .iter()
-                .filter(|&&key| key == button)
-                .take(MAX as usize)
-                .count() as u8,
+            Button::Key(button) => {
+                input
+                    .1
+                    .keys_hit
+                    .iter()
+                    .filter(|&&key| key == button)
+                    .take(MAX as usize)
+                    .count() as u8
+            }
+            Button::Mouse(button) => {
+                input
+                    .1
+                    .mouse_hit
+                    .iter()
+                    .filter(|&&key| key == button)
+                    .take(MAX as usize)
+                    .count() as u8
+            }
         }
     }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -771,7 +771,9 @@ impl Renderer {
                                 .unwrap_or(&self.map_default)
                                 .to_param()
                         },
-                        normal_map: { normal_map.as_ref().unwrap_or(&self.map_default).to_param() },
+                        normal_map: {
+                            normal_map.as_ref().unwrap_or(&self.map_default).to_param()
+                        },
                         emissive_map: {
                             emissive_map
                                 .as_ref()
@@ -908,8 +910,10 @@ impl Renderer {
             if let SubNode::UiText(ref text) = node.sub_node {
                 text.font.queue(&text.section, text.layout);
                 if !self.font_cache.contains_key(&text.font.path) {
-                    self.font_cache
-                        .insert(text.font.path.clone(), text.font.clone());
+                    self.font_cache.insert(
+                        text.font.path.clone(),
+                        text.font.clone(),
+                    );
                 }
             }
         }
@@ -933,10 +937,12 @@ impl Renderer {
                 },
             ];
             let p0 = self.map_to_ndc([pos[0] as f32, pos[1] as f32]);
-            let p1 = self.map_to_ndc([
-                (pos[0] + quad.size[0]) as f32,
-                (pos[1] + quad.size[1]) as f32,
-            ]);
+            let p1 = self.map_to_ndc(
+                [
+                    (pos[0] + quad.size[0]) as f32,
+                    (pos[1] + quad.size[1]) as f32,
+                ],
+            );
             self.encoder.update_constant_buffer(
                 &self.quad_buf,
                 &QuadParams {

--- a/src/text.rs
+++ b/src/text.rs
@@ -112,9 +112,9 @@ impl Font {
         out: &RenderTargetView<BackendResources, ColorFormat>,
     ) {
         let mut brush = self.brush.borrow_mut();
-        brush
-            .draw_queued(encoder, out)
-            .expect("Error while drawing text");
+        brush.draw_queued(encoder, out).expect(
+            "Error while drawing text",
+        );
     }
 }
 

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -35,12 +35,7 @@ impl<T> Texture<T> {
         }
     }
 
-    pub(crate) fn to_param(
-        &self,
-    ) -> (
-        h::ShaderResourceView<BackendResources, T>,
-        h::Sampler<BackendResources>,
-    ) {
+    pub(crate) fn to_param(&self) -> (h::ShaderResourceView<BackendResources, T>, h::Sampler<BackendResources>) {
         (self.view.clone(), self.sampler.clone())
     }
 
@@ -118,12 +113,7 @@ impl<T> CubeMap<T> {
         CubeMap { view, sampler }
     }
 
-    pub(crate) fn to_param(
-        &self,
-    ) -> (
-        h::ShaderResourceView<BackendResources, T>,
-        h::Sampler<BackendResources>,
-    ) {
+    pub(crate) fn to_param(&self) -> (h::ShaderResourceView<BackendResources, T>, h::Sampler<BackendResources>) {
         (self.view.clone(), self.sampler.clone())
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -141,40 +141,44 @@ impl Window {
         self.event_loop.poll_events(|event| {
             use glutin::WindowEvent::{Closed, KeyboardInput, MouseInput, MouseMoved, MouseWheel, Resized};
             match event {
-                glutin::Event::WindowEvent { event, .. } => match event {
-                    Resized(..) => renderer.resize(window),
-                    Closed => running = false,
-                    KeyboardInput {
-                        input: glutin::KeyboardInput {
-                            state,
-                            virtual_keycode: Some(keycode),
+                glutin::Event::WindowEvent { event, .. } => {
+                    match event {
+                        Resized(..) => renderer.resize(window),
+                        Closed => running = false,
+                        KeyboardInput {
+                            input: glutin::KeyboardInput {
+                                state,
+                                virtual_keycode: Some(keycode),
+                                ..
+                            },
                             ..
-                        },
-                        ..
-                    } => input.keyboard_input(state, keycode),
-                    MouseInput { state, button, .. } => input.mouse_input(state, button),
-                    MouseMoved {
-                        position: (x, y), ..
-                    } => input.mouse_moved(
-                        [x as f32, y as f32].into(),
-                        renderer.map_to_ndc([x as f32, y as f32]),
-                    ),
-                    MouseWheel { delta, .. } => input.mouse_wheel_input(delta),
-                    _ => {}
-                },
-                glutin::Event::DeviceEvent { event, .. } => match event {
-                    glutin::DeviceEvent::Motion { axis, value } => {
-                        let delta = if axis == 0 {
-                            [value as f32, 0.0].into()
-                        } else if axis == 1 {
-                            [0.0, value as f32].into()
-                        } else {
-                            return;
-                        };
-                        input.mouse_moved_raw(delta);
+                        } => input.keyboard_input(state, keycode),
+                        MouseInput { state, button, .. } => input.mouse_input(state, button),
+                        MouseMoved { position: (x, y), .. } => {
+                            input.mouse_moved(
+                                [x as f32, y as f32].into(),
+                                renderer.map_to_ndc([x as f32, y as f32]),
+                            )
+                        }
+                        MouseWheel { delta, .. } => input.mouse_wheel_input(delta),
+                        _ => {}
                     }
-                    _ => {}
-                },
+                }
+                glutin::Event::DeviceEvent { event, .. } => {
+                    match event {
+                        glutin::DeviceEvent::Motion { axis, value } => {
+                            let delta = if axis == 0 {
+                                [value as f32, 0.0].into()
+                            } else if axis == 1 {
+                                [0.0, value as f32].into()
+                            } else {
+                                return;
+                            };
+                            input.mouse_moved_raw(delta);
+                        }
+                        _ => {}
+                    }
+                }
                 _ => {}
             }
         });
@@ -192,9 +196,9 @@ impl Window {
 
     /// Get current window size in pixels.
     pub fn size(&self) -> mint::Vector2<f32> {
-        let size = self.window
-            .get_inner_size_pixels()
-            .expect("Can't get window size");
+        let size = self.window.get_inner_size_pixels().expect(
+            "Can't get window size",
+        );
         [size.0 as f32, size.1 as f32].into()
     }
 


### PR DESCRIPTION
Adds runnable code examples to the geometry module documentation.

This also renames `Geometry::sphere` as `Geometry::uv_sphere` to make way for icosahedral spheres.