### PR TITLE
[WIP] Shader code system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ keywords = ["gamedev", "graphics", "engine", "3D"]
 homepage = "https://github.com/kvark/three-rs"
 repository = "https://github.com/kvark/three-rs"
 documentation = "https://docs.rs/three/"
+build = "build.rs"
+include = ["data"]
 exclude = ["doc", "bors.toml", ".travis.yml", "test_data"]
 
 [lib]
@@ -16,6 +18,9 @@ exclude = ["doc", "bors.toml", ".travis.yml", "test_data"]
 [features]
 default = ["opengl"]
 "opengl" = ["gfx_device_gl", "gfx_window_glutin", "glutin"]
+
+[build-dependencies]
+includedir_codegen = "0.2.0"
 
 [dependencies]
 bitflags = "0.9"
@@ -28,9 +33,12 @@ gltf = "0.9.1"
 gltf-importer = "0.9.1"
 gltf-utils = "0.9.1"
 image = "0.13"
+includedir = "0.2.0"
 itertools = "0.6"
+lazy_static = "0.2"
 log = "0.3"
 obj = { version = "0.6", features = ["genmesh"] }
+phf = "0.7.12"
 rodio = "0.5"
 mint = "0.4.2"
 vec_map = "0.8"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,10 @@
+extern crate includedir_codegen;
+
+use includedir_codegen::Compression;
+
+fn main() {
+    includedir_codegen::start("SHADERS")
+        .dir("data/shaders", Compression::None)
+        .build("data.rs")
+        .unwrap();
+}

--- a/examples/anim.rs
+++ b/examples/anim.rs
@@ -98,9 +98,7 @@ fn make_geometry() -> three::Geometry {
 }
 
 fn main() {
-    let shaders_path: String = format!("{}/data/shaders", env!("CARGO_MANIFEST_DIR"));
-    let shaders_path_str: &str = shaders_path.as_str();
-    let mut win = three::Window::builder("Three-rs mesh blending example", shaders_path_str).build();
+    let mut win = three::Window::new("Three-rs mesh blending example");
     let mut cam = win.factory.perspective_camera(60.0, 1.0 .. 1000.0);
     cam.look_at(
         [100.0, 0.0, 100.0],

--- a/examples/aviator/main.rs
+++ b/examples/aviator/main.rs
@@ -22,9 +22,7 @@ fn main() {
     env_logger::init().unwrap();
     let mut rng = rand::thread_rng();
 
-    let shaders_path: String = format!("{}/data/shaders", env!("CARGO_MANIFEST_DIR"));
-    let shaders_path_str: &str = shaders_path.as_str();
-    let mut win = three::Window::builder("Three-rs Aviator demo", shaders_path_str).build();
+    let mut win = three::Window::new("Three-rs Aviator demo");
     win.scene.background = three::Background::Color(COLOR_BACKGROUND);
 
     let mut cam = win.factory.perspective_camera(60.0, 1.0 .. 1000.0);

--- a/examples/gltf.rs
+++ b/examples/gltf.rs
@@ -1,8 +1,7 @@
 extern crate three;
 
 fn main() {
-    let shaders = concat!(env!("CARGO_MANIFEST_DIR"), "/data/shaders");
-    let mut win = three::Window::builder("Three-rs glTF example", &shaders).build();
+    let mut win = three::Window::new("Three-rs glTF example");
     let mut light = win.factory.directional_light(0xFFFFFF, 7.0);
     light.look_at([1.0, 1.0, 1.0], [0.0, 0.0, 0.0], None);
     win.scene.add(&light);

--- a/examples/group.rs
+++ b/examples/group.rs
@@ -113,9 +113,7 @@ const SPEEDS: [f32; 5] = [
 ];
 
 fn main() {
-    let shaders_path: String = format!("{}/data/shaders", env!("CARGO_MANIFEST_DIR"));
-    let shaders_path_str: &str = shaders_path.as_str();
-    let mut win = three::Window::builder("Three-rs group example", shaders_path_str).build();
+    let mut win = three::Window::new("Three-rs group example");
     win.scene.background = three::Background::Color(0x204060);
 
     let mut cam = win.factory.perspective_camera(60.0, 1.0 .. 100.0);

--- a/examples/lights.rs
+++ b/examples/lights.rs
@@ -1,9 +1,7 @@
 extern crate three;
 
 fn main() {
-    let shaders_path: String = format!("{}/data/shaders", env!("CARGO_MANIFEST_DIR"));
-    let shaders_path_str: &str = shaders_path.as_str();
-    let mut win = three::Window::builder("Three-rs lights example", shaders_path_str).build();
+    let mut win = three::Window::new("Three-rs lights example");
     let mut cam = win.factory.perspective_camera(45.0, 1.0 .. 50.0);
     cam.look_at([-4.0, 15.0, 10.0], [0.0, 0.0, 2.0], None);
 

--- a/examples/materials.rs
+++ b/examples/materials.rs
@@ -1,9 +1,7 @@
 extern crate three;
 
 fn main() {
-    let shaders_path: String = format!("{}/data/shaders", env!("CARGO_MANIFEST_DIR"));
-    let shaders_path_str: &str = shaders_path.as_str();
-    let mut win = three::Window::builder("Three-rs materials example", shaders_path_str).build();
+    let mut win = three::Window::new("Three-rs materials example");
     let mut cam = win.factory.perspective_camera(75.0, 1.0 .. 50.0);
     cam.set_position([0.0, 0.0, 10.0]);
 

--- a/examples/obj.rs
+++ b/examples/obj.rs
@@ -4,11 +4,9 @@ use std::env;
 
 fn main() {
     let mut args = env::args();
-    let obj_path: String = format!("{}/test_data/car.obj", env!("CARGO_MANIFEST_DIR"));
-    let path = args.nth(1).unwrap_or(obj_path);
-    let shaders_path: String = format!("{}/data/shaders", env!("CARGO_MANIFEST_DIR"));
-    let shaders_path_str: &str = shaders_path.as_str();
-    let mut win = three::Window::builder("Three-rs obj loading example", shaders_path_str).build();
+    let obj_path = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/car.obj");
+    let path = args.nth(1).unwrap_or(obj_path.into());
+    let mut win = three::Window::new("Three-rs obj loading example");
     let cam = win.factory.perspective_camera(60.0, 1.0 .. 10.0);
     let mut controls = three::controls::Orbit::builder(&cam)
         .position([0.0, 2.0, -5.0])

--- a/examples/shapes.rs
+++ b/examples/shapes.rs
@@ -5,9 +5,7 @@ extern crate three;
 use cgmath::prelude::*;
 
 fn main() {
-    let shaders_path: String = format!("{}/data/shaders", env!("CARGO_MANIFEST_DIR"));
-    let shaders_path_str: &str = shaders_path.as_str();
-    let mut win = three::Window::builder("Three-rs shapes example", shaders_path_str).build();
+    let mut win = three::Window::new("Three-rs shapes example");
     let mut cam = win.factory.perspective_camera(75.0, 1.0 .. 50.0);
     cam.set_position([0.0, 0.0, 10.0]);
 

--- a/examples/sprite.rs
+++ b/examples/sprite.rs
@@ -42,9 +42,7 @@ impl Animator {
 }
 
 fn main() {
-    let shaders_path: String = format!("{}/data/shaders", env!("CARGO_MANIFEST_DIR"));
-    let shaders_path_str: &str = shaders_path.as_str();
-    let mut win = three::Window::builder("Three-rs sprite example", shaders_path_str).build();
+    let mut win = three::Window::new("Three-rs sprite example");
     let cam = win.factory.orthographic_camera(
         [0.0, 0.0],
         10.0,

--- a/examples/tutorial.rs
+++ b/examples/tutorial.rs
@@ -1,9 +1,7 @@
 extern crate three;
 
 fn main() {
-    let title = "Getting started with three-rs";
-    let shaders = concat!(env!("CARGO_MANIFEST_DIR"), "/data/shaders");
-    let mut window = three::Window::builder(title, shaders).build();
+    let mut window = three::Window::new("Getting started with three-rs");
 
     let vertices = vec![
         [-0.5, -0.5, -0.5].into(),

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -12,7 +12,7 @@
 //! [`Factory::perspective_camera`] method with a bounded range.
 //!
 //! ```rust,no_run
-//! # let mut window = three::Window::builder("", "").build();
+//! # let mut window = three::Window::new("");
 //! # let _ = {
 //! window.factory.perspective_camera(60.0, 0.1 .. 1.0);
 //! # };
@@ -28,7 +28,7 @@
 //! [`Factory::perspective_camera`] method with an unbounded range.
 //!
 //! ```rust,no_run
-//! # let mut window = three::Window::builder("", "").build();
+//! # let mut window = three::Window::new("");
 //! # let _ = {
 //! window.factory.perspective_camera(60.0, 0.1 ..);
 //! # };
@@ -44,7 +44,7 @@
 //! [`Factory::orthographic_camera`] method.
 //!
 //! ```rust,no_run
-//! # let mut window = three::Window::builder("", "").build();
+//! # let mut window = three::Window::new("");
 //! # let _ = {
 //! window.factory.orthographic_camera([0.0, 0.0], 1.0, -1.0 .. 1.0)
 //! # };

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,0 +1,5 @@
+//! The contents of this module is automatically generated.
+//!
+//! See `build.rs` for the code generator.
+
+include!(concat!(env!("OUT_DIR"), "/data.rs"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,15 +5,13 @@
 //!
 //! ## Creating a window
 //!
-//! Every `three` application begins with a [`Window`]. We begin by setting the title
-//! of this window, and define the path to the shader code directory.
+//! Every `three` application begins with a [`Window`]. We create it as follows.
 //!
 //! ```rust,no_run
 //! # extern crate three;
 //! # fn main() {
 //! let title = "Getting started with three-rs";
-//! let shaders = concat!(env!("CARGO_MANIFEST_DIR"), "/data/shaders");
-//! let mut window = three::Window::builder(title, shaders).build();
+//! let mut window = three::Window::new(title);
 //! # }
 //! ```
 //!
@@ -37,8 +35,7 @@
 //! # extern crate three;
 //! # fn main() {
 //! # let title = "Getting started with three-rs";
-//! # let shaders = concat!(env!("CARGO_MANIFEST_DIR"), "/data/shaders");
-//! # let mut window = three::Window::builder(title, shaders).build();
+//! # let mut window = three::Window::new(title);
 //! let geometry = three::Geometry::with_vertices(vec![
 //!     [-0.5, -0.5, -0.5].into(),
 //!     [ 0.5, -0.5, -0.5].into(),
@@ -63,8 +60,7 @@
 //! # extern crate three;
 //! # fn main() {
 //! # let title = "Getting started with three-rs";
-//! # let shaders = concat!(env!("CARGO_MANIFEST_DIR"), "/data/shaders");
-//! # let mut window = three::Window::builder(title, shaders).build();
+//! # let mut window = three::Window::new(title);
 //! # let vertices = vec![
 //! #     [-0.5, -0.5, -0.5].into(),
 //! #     [ 0.5, -0.5, -0.5].into(),
@@ -89,8 +85,7 @@
 //! # extern crate three;
 //! # fn main() {
 //! # let title = "Getting started with three-rs";
-//! # let shaders = concat!(env!("CARGO_MANIFEST_DIR"), "/data/shaders");
-//! # let mut window = three::Window::builder(title, shaders).build();
+//! # let mut window = three::Window::new(title);
 //! window.scene.background = three::Background::Color(0xC6F0FF);
 //! # }
 //! ```
@@ -104,8 +99,7 @@
 //! # extern crate three;
 //! # fn main() {
 //! #     let title = "Getting started with three-rs";
-//! #     let shaders = concat!(env!("CARGO_MANIFEST_DIR"), "/data/shaders");
-//! #     let mut window = three::Window::builder(title, shaders).build();
+//! #     let mut window = three::Window::new(title);
 //! #     let vertices = vec![
 //! #         [-0.5, -0.5, -0.5].into(),
 //! #         [ 0.5, -0.5, -0.5].into(),
@@ -139,8 +133,7 @@
 //!
 //! fn main() {
 //!     let title = "Getting started with three-rs";
-//!     let shaders = concat!(env!("CARGO_MANIFEST_DIR"), "/data/shaders");
-//!     let mut window = three::Window::builder(title, shaders).build();
+//!     let mut window = three::Window::new(title);
 //!
 //!     let vertices = vec![
 //!         [-0.5, -0.5, -0.5].into(),
@@ -189,7 +182,7 @@
 //! }
 //!
 //! fn main() {
-//! #    let mut window = three::Window::builder("", "").build();
+//! #    let mut window = three::Window::new("");
 //!     // Initialization code omitted.
 //!     let my_object = MyObject { group: window.factory.group() };
 //!     window.scene.add(&my_object);
@@ -255,12 +248,16 @@ extern crate gltf;
 extern crate gltf_importer;
 extern crate gltf_utils;
 extern crate image;
+extern crate includedir;
 #[macro_use]
 extern crate itertools;
+#[macro_use]
+extern crate lazy_static;
 #[macro_use]
 extern crate log;
 extern crate mint;
 extern crate obj;
+extern crate phf;
 extern crate rodio;
 extern crate vec_map;
 // OpenGL
@@ -278,6 +275,7 @@ pub mod audio;
 pub mod camera;
 pub mod controls;
 pub mod custom;
+mod data;
 mod factory;
 pub mod geometry;
 mod hub;

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -12,8 +12,7 @@ use render::DynamicData;
 /// Creating a red triangle.
 ///
 /// ```rust,no_run
-/// # let shaders_path = format!("{}/data/shaders", env!("CARGO_MANIFEST_DIR"));
-/// # let mut win = three::Window::builder("Example", &shaders_path).build();
+/// # let mut win = three::Window::new("Example");
 /// # let factory = &mut win.factory;
 /// let vertices = vec![
 ///     [-0.5, -0.5, 0.0].into(),
@@ -33,8 +32,7 @@ use render::DynamicData;
 /// Duplicating a mesh.
 ///
 /// ```rust,no_run
-/// # let shaders_path = format!("{}/data/shaders", env!("CARGO_MANIFEST_DIR"));
-/// # let mut win = three::Window::builder("Example", &shaders_path).build();
+/// # let mut win = three::Window::new("Example");
 /// # let factory = &mut win.factory;
 /// # let vertices = vec![
 /// #     [-0.5, -0.5, 0.0].into(),

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,7 +1,5 @@
 //! Primitives for creating and controlling [`Window`](struct.Window.html).
 
-use std::path::{Path, PathBuf};
-
 use glutin;
 use glutin::GlContext;
 use mint;
@@ -11,7 +9,6 @@ use factory::Factory;
 use input::Input;
 use render::Renderer;
 use scene::Scene;
-
 
 /// `Window` is the core entity of every `three-rs` application.
 ///
@@ -35,7 +32,6 @@ pub struct Builder {
     dimensions: (u32, u32),
     fullscreen: bool,
     multisampling: u16,
-    shader_path: PathBuf,
     title: String,
     vsync: bool,
 }
@@ -99,7 +95,7 @@ impl Builder {
             .with_multisampling(self.multisampling);
 
         let event_loop = glutin::EventsLoop::new();
-        let (renderer, window, mut factory) = Renderer::new(builder, context, &event_loop, &self.shader_path);
+        let (renderer, window, mut factory) = Renderer::new(builder, context, &event_loop);
         let scene = factory.scene();
         Window {
             event_loop,
@@ -113,16 +109,17 @@ impl Builder {
 }
 
 impl Window {
+    /// Create a new window with default parameters.
+    pub fn new<T: Into<String>>(title: T) -> Self {
+        Self::builder(title).build()
+    }
+
     /// Create new `Builder` with standard parameters.
-    pub fn builder<T: Into<String>, P: AsRef<Path>>(
-        title: T,
-        shader_path: P,
-    ) -> Builder {
+    pub fn builder<T: Into<String>>(title: T) -> Builder {
         Builder {
             dimensions: (1024, 768),
             fullscreen: false,
             multisampling: 0,
-            shader_path: shader_path.as_ref().to_owned(),
             title: title.into(),
             vsync: true,
         }


### PR DESCRIPTION
This is an attempt to redesign the shader code system, as discussed in issue #28.

Currently, the default shaders have been baked into the program. See `build.rs` and `src/data.rs` to find out how this was achieved. There is no way of overriding shaders yet, but one can build custom pipelines as per usual.