### PR TITLE
New material strategy

### DIFF
--- a/examples/anim.rs
+++ b/examples/anim.rs
@@ -121,11 +121,7 @@ fn main() {
 
     let mesh = win.factory.mesh_dynamic(
         geom,
-        three::material::Basic {
-            color: 0xffffff,
-            map: None,
-            pipeline: three::material::basic::Pipeline::Wireframe,
-        },
+        three::material::Wireframe { color: 0xFFFFFF },
     );
     win.scene.add(&mesh);
 

--- a/examples/anim.rs
+++ b/examples/anim.rs
@@ -121,10 +121,10 @@ fn main() {
 
     let mesh = win.factory.mesh_dynamic(
         geom,
-        three::Material::MeshBasic {
+        three::material::Basic {
             color: 0xffffff,
             map: None,
-            wireframe: true,
+            pipeline: three::material::basic::Pipeline::Wireframe,
         },
     );
     win.scene.add(&mesh);

--- a/examples/aviator/main.rs
+++ b/examples/aviator/main.rs
@@ -44,7 +44,7 @@ fn main() {
 
     let mut sea = {
         let geo = three::Geometry::cylinder(600.0, 600.0, 800.0, 40);
-        let material = three::Material::MeshLambert {
+        let material = three::material::Lambert {
             color: COLOR_BLUE,
             flat: true,
         };

--- a/examples/aviator/plane.rs
+++ b/examples/aviator/plane.rs
@@ -4,7 +4,6 @@ use three;
 
 use {COLOR_BROWN, COLOR_BROWN_DARK, COLOR_RED, COLOR_WHITE};
 
-
 pub struct AirPlane {
     pub group: three::Group,
     _cockpit: three::Mesh,
@@ -30,7 +29,7 @@ impl AirPlane {
             }
             factory.mesh(
                 geo,
-                three::Material::MeshLambert {
+                three::material::Lambert {
                     color: COLOR_RED,
                     flat: false,
                 },
@@ -39,7 +38,7 @@ impl AirPlane {
         group.add(&cockpit);
         let mut engine = factory.mesh(
             three::Geometry::cuboid(20.0, 50.0, 50.0),
-            three::Material::MeshLambert {
+            three::material::Lambert {
                 color: COLOR_WHITE,
                 flat: false,
             },
@@ -48,7 +47,7 @@ impl AirPlane {
         group.add(&engine);
         let mut tail = factory.mesh(
             three::Geometry::cuboid(15.0, 20.0, 5.0),
-            three::Material::MeshLambert {
+            three::material::Lambert {
                 color: COLOR_RED,
                 flat: false,
             },
@@ -57,7 +56,7 @@ impl AirPlane {
         group.add(&tail);
         let wing = factory.mesh(
             three::Geometry::cuboid(40.0, 8.0, 150.0),
-            three::Material::MeshLambert {
+            three::material::Lambert {
                 color: COLOR_RED,
                 flat: false,
             },
@@ -69,7 +68,7 @@ impl AirPlane {
         group.add(&propeller_group);
         let propeller = factory.mesh(
             three::Geometry::cuboid(20.0, 10.0, 10.0),
-            three::Material::MeshLambert {
+            three::material::Lambert {
                 color: COLOR_BROWN,
                 flat: false,
             },
@@ -77,7 +76,7 @@ impl AirPlane {
         propeller_group.add(&propeller);
         let mut blade = factory.mesh(
             three::Geometry::cuboid(1.0, 100.0, 20.0),
-            three::Material::MeshLambert {
+            three::material::Lambert {
                 color: COLOR_BROWN_DARK,
                 flat: false,
             },

--- a/examples/aviator/sky.rs
+++ b/examples/aviator/sky.rs
@@ -23,13 +23,13 @@ impl Cloud {
             meshes: Vec::new(),
         };
         let geo = three::Geometry::cuboid(20.0, 20.0, 20.0);
-        let material = three::Material::MeshLambert {
+        let material = three::material::Lambert {
             color: COLOR_WHITE,
             flat: true,
         };
         let template = factory.mesh(geo, material.clone());
         for i in 0i32 .. rng.gen_range(3, 6) {
-            let mut m = factory.mesh_instance(&template, None);
+            let mut m = factory.mesh_instance(&template);
             let rot: cgmath::Quaternion<f32> = rng.gen();
             let q = rot.normalize();
             m.set_transform(

--- a/examples/group.rs
+++ b/examples/group.rs
@@ -17,7 +17,7 @@ struct Cube {
 
 fn create_cubes(
     factory: &mut three::Factory,
-    materials: &[three::Material],
+    materials: &[three::material::Lambert],
     levels: &[Level],
 ) -> Vec<Cube> {
     let mut geometry = three::Geometry::cuboid(2.0, 2.0, 2.0);
@@ -79,7 +79,7 @@ fn create_cubes(
             let mat = materials[next.mat_id].clone();
             let mut cube = Cube {
                 group: factory.group(),
-                mesh: factory.mesh_instance(&list[0].mesh, Some(mat)),
+                mesh: factory.mesh_instance_with_material(&list[0].mesh, mat),
                 level_id: next.lev_id,
                 orientation: child.rot,
             };
@@ -125,7 +125,7 @@ fn main() {
 
     let materials: Vec<_> = COLORS
         .iter()
-        .map(|&color| three::Material::MeshLambert { color, flat: false })
+        .map(|&color| three::material::Lambert { color, flat: false })
         .collect();
     let levels: Vec<_> = SPEEDS.iter().map(|&speed| Level { speed }).collect();
     let mut cubes = create_cubes(&mut win.factory, &materials, &levels);

--- a/examples/lights.rs
+++ b/examples/lights.rs
@@ -34,7 +34,7 @@ fn main() {
 
     let mut sphere = {
         let geometry = three::Geometry::uv_sphere(3.0, 20, 20);
-        let material = three::Material::MeshPhong {
+        let material = three::material::Phong {
             color: 0xffA0A0,
             glossiness: 80.0,
         };
@@ -45,7 +45,7 @@ fn main() {
 
     let mut plane = {
         let geometry = three::Geometry::plane(100.0, 100.0);
-        let material = three::Material::MeshLambert {
+        let material = three::material::Lambert {
             color: 0xA0ffA0,
             flat: false,
         };

--- a/examples/materials.rs
+++ b/examples/materials.rs
@@ -15,7 +15,6 @@ fn main() {
         three::material::Basic {
             color: 0xFFFFFF,
             map: None,
-            ..Default::default()
         }.into(),
         three::material::Lambert {
             color: 0xFFFFFF,

--- a/examples/materials.rs
+++ b/examples/materials.rs
@@ -11,36 +11,38 @@ fn main() {
     win.scene.add(&light);
 
     let geometry = three::Geometry::cylinder(1.0, 2.0, 2.0, 5);
-    let mut materials = vec![
-        three::Material::MeshBasic {
-            color: 0xffffff,
+    let mut materials: Vec<three::Material> = vec![
+        three::material::Basic {
+            color: 0xFFFFFF,
             map: None,
-            wireframe: false,
-        },
-        three::Material::MeshLambert {
-            color: 0xffffff,
+            ..Default::default()
+        }.into(),
+        three::material::Lambert {
+            color: 0xFFFFFF,
             flat: true,
-        },
-        three::Material::MeshLambert {
-            color: 0xffffff,
+        }.into(),
+        three::material::Lambert {
+            color: 0xFFFFFF,
             flat: false,
-        },
-        three::Material::MeshPhong {
-            color: 0xffffff,
+        }.into(),
+        three::material::Phong {
+            color: 0xFFFFFF,
             glossiness: 80.0,
-        },
-        three::Material::MeshPbr {
-            base_color_factor: [0.2, 0.2, 0.2, 1.0],
-            metallic_roughness: [0.5, 0.5],
+        }.into(),
+        three::material::Pbr {
+            base_color_factor: 0xFFFFFF,
+            base_color_alpha: 1.0,
+            metallic_factor: 0.5,
+            roughness_factor: 0.5,
             occlusion_strength: 0.2,
-            emissive_factor: [0.0, 0.0, 0.0],
+            emissive_factor: 0x000000,
             normal_scale: 1.0,
             base_color_map: None,
             normal_map: None,
             emissive_map: None,
             metallic_roughness_map: None,
             occlusion_map: None,
-        },
+        }.into(),
     ];
     let count = materials.len();
 

--- a/examples/mesh-update.rs
+++ b/examples/mesh-update.rs
@@ -48,7 +48,7 @@ fn main() {
         .build();
 
     let geometry = make_tetrahedron_geometry();
-    let material = three::material::Basic { color: 0xFFFF00, .. Default::default() };
+    let material = three::material::Wireframe { color: 0xFFFF00 };
     let mut mesh = win.factory.mesh_dynamic(geometry, material);
     let vertex_count = mesh.vertex_count();
     win.scene.add(&mesh);

--- a/examples/mesh-update.rs
+++ b/examples/mesh-update.rs
@@ -48,10 +48,7 @@ fn main() {
         .build();
 
     let geometry = make_tetrahedron_geometry();
-    let material = three::material::Basic {
-        color: 0xFFFF00,
-        ..Default::default()
-    };
+    let material = three::material::Basic { color: 0xFFFF00, .. Default::default() };
     let mut mesh = win.factory.mesh_dynamic(geometry, material);
     let vertex_count = mesh.vertex_count();
     win.scene.add(&mesh);

--- a/examples/mesh-update.rs
+++ b/examples/mesh-update.rs
@@ -48,10 +48,9 @@ fn main() {
         .build();
 
     let geometry = make_tetrahedron_geometry();
-    let material = three::Material::MeshBasic {
+    let material = three::material::Basic {
         color: 0xFFFF00,
-        wireframe: true,
-        map: None,
+        ..Default::default()
     };
     let mut mesh = win.factory.mesh_dynamic(geometry, material);
     let vertex_count = mesh.vertex_count();

--- a/examples/reload.rs
+++ b/examples/reload.rs
@@ -84,7 +84,7 @@ fn main() {
         1.0,
         -1.0 .. 1.0,
     );
- 
+
     let (tx, rx) = mpsc::channel();
     let mut watcher = notify::watcher(tx, Duration::from_secs(1)).unwrap();
     watcher
@@ -93,7 +93,7 @@ fn main() {
 
     let map_path = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/gradient.png");
     let map = win.factory.load_texture(map_path);
-    let material = three::Material::Sprite { map };
+    let material = three::material::Sprite { map };
     let mut sprite = win.factory.sprite(material);
     sprite.set_scale(1.0);
     win.scene.add(&sprite);

--- a/examples/shapes.rs
+++ b/examples/shapes.rs
@@ -11,7 +11,7 @@ fn main() {
 
     let mut mbox = {
         let geometry = three::Geometry::cuboid(3.0, 2.0, 1.0);
-        let material = three::material::Basic { color: 0x00FF00, map: None };
+        let material = three::material::Wireframe { color: 0x00FF00 };
         win.factory.mesh(geometry, material)
     };
     mbox.set_position([-3.0, -3.0, 0.0]);
@@ -19,7 +19,7 @@ fn main() {
 
     let mut mcyl = {
         let geometry = three::Geometry::cylinder(1.0, 2.0, 2.0, 5);
-        let material = three::material::Basic { color: 0xFF0000, map: None };
+        let material = three::material::Wireframe { color: 0xFF0000 };
         win.factory.mesh(geometry, material)
     };
     mcyl.set_position([3.0, -3.0, 0.0]);
@@ -27,7 +27,7 @@ fn main() {
 
     let mut msphere = {
         let geometry = three::Geometry::uv_sphere(2.0, 5, 5);
-        let material = three::material::Basic { color: 0xFF0000, map: None };
+        let material = three::material::Wireframe { color: 0xFF0000 };
         win.factory.mesh(geometry, material)
     };
     msphere.set_position([-3.0, 3.0, 0.0]);

--- a/examples/shapes.rs
+++ b/examples/shapes.rs
@@ -11,11 +11,7 @@ fn main() {
 
     let mut mbox = {
         let geometry = three::Geometry::cuboid(3.0, 2.0, 1.0);
-        let material = three::material::Basic {
-            color: 0x00ff00,
-            map: None,
-            pipeline: three::material::basic::Pipeline::Wireframe,
-        };
+        let material = three::material::Basic { color: 0x00FF00, map: None };
         win.factory.mesh(geometry, material)
     };
     mbox.set_position([-3.0, -3.0, 0.0]);
@@ -23,11 +19,7 @@ fn main() {
 
     let mut mcyl = {
         let geometry = three::Geometry::cylinder(1.0, 2.0, 2.0, 5);
-        let material = three::material::Basic {
-            color: 0xff0000,
-            map: None,
-            pipeline: three::material::basic::Pipeline::Wireframe,
-        };
+        let material = three::material::Basic { color: 0xFF0000, map: None };
         win.factory.mesh(geometry, material)
     };
     mcyl.set_position([3.0, -3.0, 0.0]);
@@ -35,15 +27,23 @@ fn main() {
 
     let mut msphere = {
         let geometry = three::Geometry::uv_sphere(2.0, 5, 5);
-        let material = three::material::Basic {
-            color: 0xff0000,
-            map: None,
-            pipeline: three::material::basic::Pipeline::Wireframe,
-        };
+        let material = three::material::Basic { color: 0xFF0000, map: None };
         win.factory.mesh(geometry, material)
     };
     msphere.set_position([-3.0, 3.0, 0.0]);
     win.scene.add(&msphere);
+
+    let mut mline = {
+        let geometry = three::Geometry::with_vertices(vec![
+            [-2.0, -1.0, 0.0].into(),
+            [0.0, 1.0, 0.0].into(),
+            [2.0, -1.0, 0.0].into(),
+        ]);
+        let material = three::material::Line { color: 0x0000FF };
+        win.factory.mesh(geometry, material)
+    };
+    mline.set_position([3.0, 3.0, 0.0]);
+    win.scene.add(&mline);
 
     let mut angle = cgmath::Rad::zero();
     while win.update() && !three::KEY_ESCAPE.is_hit(&win.input) {
@@ -53,8 +53,8 @@ fn main() {
             mbox.set_orientation(q);
             mcyl.set_orientation(q);
             msphere.set_orientation(q);
+            mline.set_orientation(q);
         }
-
         win.render(&cam);
     }
 }

--- a/examples/shapes.rs
+++ b/examples/shapes.rs
@@ -11,10 +11,10 @@ fn main() {
 
     let mut mbox = {
         let geometry = three::Geometry::cuboid(3.0, 2.0, 1.0);
-        let material = three::Material::MeshBasic {
+        let material = three::material::Basic {
             color: 0x00ff00,
             map: None,
-            wireframe: true,
+            pipeline: three::material::basic::Pipeline::Wireframe,
         };
         win.factory.mesh(geometry, material)
     };
@@ -23,10 +23,10 @@ fn main() {
 
     let mut mcyl = {
         let geometry = three::Geometry::cylinder(1.0, 2.0, 2.0, 5);
-        let material = three::Material::MeshBasic {
+        let material = three::material::Basic {
             color: 0xff0000,
             map: None,
-            wireframe: true,
+            pipeline: three::material::basic::Pipeline::Wireframe,
         };
         win.factory.mesh(geometry, material)
     };
@@ -35,27 +35,15 @@ fn main() {
 
     let mut msphere = {
         let geometry = three::Geometry::uv_sphere(2.0, 5, 5);
-        let material = three::Material::MeshBasic {
+        let material = three::material::Basic {
             color: 0xff0000,
             map: None,
-            wireframe: true,
+            pipeline: three::material::basic::Pipeline::Wireframe,
         };
         win.factory.mesh(geometry, material)
     };
     msphere.set_position([-3.0, 3.0, 0.0]);
     win.scene.add(&msphere);
-
-    let mut mline = {
-        let geometry = three::Geometry::with_vertices(vec![
-            [-2.0, -1.0, 0.0].into(),
-            [0.0, 1.0, 0.0].into(),
-            [2.0, -1.0, 0.0].into(),
-        ]);
-        let material = three::Material::LineBasic { color: 0x0000ff };
-        win.factory.mesh(geometry, material)
-    };
-    mline.set_position([3.0, 3.0, 0.0]);
-    win.scene.add(&mline);
 
     let mut angle = cgmath::Rad::zero();
     while win.update() && !three::KEY_ESCAPE.is_hit(&win.input) {
@@ -64,7 +52,6 @@ fn main() {
             let q = cgmath::Quaternion::from_angle_y(angle);
             mbox.set_orientation(q);
             mcyl.set_orientation(q);
-            mline.set_orientation(q);
             msphere.set_orientation(q);
         }
 

--- a/examples/sprite.rs
+++ b/examples/sprite.rs
@@ -51,7 +51,7 @@ fn main() {
 
     let pikachu_path: String = format!("{}/test_data/pikachu_anim.png", env!("CARGO_MANIFEST_DIR"));
     let pikachu_path_str: &str = pikachu_path.as_str();
-    let material = three::Material::Sprite { map: win.factory.load_texture(pikachu_path_str) };
+    let material = three::material::Sprite { map: win.factory.load_texture(pikachu_path_str) };
     let mut sprite = win.factory.sprite(material);
     sprite.set_scale(8.0);
     win.scene.add(&sprite);

--- a/examples/tutorial.rs
+++ b/examples/tutorial.rs
@@ -9,10 +9,10 @@ fn main() {
         [0.0, 0.5, -0.5].into(),
     ];
     let geometry = three::Geometry::with_vertices(vertices);
-    let material = three::Material::MeshBasic {
+    let material = three::material::Basic {
         color: 0xFFFF00,
-        wireframe: false,
         map: None,
+        pipeline: three::material::basic::Pipeline::Solid,
     };
     let mesh = window.factory.mesh(geometry, material);
 

--- a/examples/tutorial.rs
+++ b/examples/tutorial.rs
@@ -9,11 +9,7 @@ fn main() {
         [0.0, 0.5, -0.5].into(),
     ];
     let geometry = three::Geometry::with_vertices(vertices);
-    let material = three::material::Basic {
-        color: 0xFFFF00,
-        map: None,
-        pipeline: three::material::basic::Pipeline::Solid,
-    };
+    let material = three::material::Basic { color: 0xFFFF00, map: None };
     let mesh = window.factory.mesh(geometry, material);
 
     window.scene.add(&mesh);

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -343,7 +343,7 @@ impl Action {
 impl Mixer {
     fn process_messages(&mut self) {
         while let Ok((weak_ptr, operation)) = self.rx.try_recv() {
-            let mut action = match weak_ptr.upgrade() {
+            let action = match weak_ptr.upgrade() {
                 Ok(ptr) => &mut self.actions[&ptr],
                 Err(_) => continue,
             };
@@ -364,7 +364,7 @@ impl Mixer {
         &mut self,
         delta_time: f32,
     ) {
-        for mut action in self.actions.iter_mut() {
+        for action in self.actions.iter_mut() {
             action.update(delta_time);
         }
     }

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,0 +1,65 @@
+//! sRGB colors.
+
+/// sRGB color represented by a 4-byte hexadecimal number.
+///
+/// ```rust
+/// let red = 0xFF0000;
+/// let green = 0x00FF00;
+/// let blue = 0x0000FF;
+/// ```
+pub type Color = u32;
+
+/// Black.
+pub const BLACK: Color = 0x000000;
+
+/// Red.
+pub const RED: Color = 0xFF0000;
+
+/// Green.
+pub const GREEN: Color = 0x00FF00;
+
+/// Blue.
+pub const BLUE: Color = 0x0000FF;
+
+/// Yellow.
+pub const YELLOW: Color = RED | GREEN;
+
+/// Cyan.
+pub const CYAN: Color = GREEN | BLUE;
+
+/// Magenta.
+pub const MAGENTA: Color = RED | BLUE;
+
+/// White.
+pub const WHITE: Color = RED | BLUE | GREEN;
+
+/// sRGB to linear conversion.
+///
+/// Implementation taken from https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_texture_sRGB_decode.txt
+pub fn to_linear_rgb(c: Color) -> [f32; 3] {
+    let f = |xu: u32| {
+        let x = (xu & 0xFF) as f32 / 255.0;
+        if x > 0.04045 {
+            ((x + 0.055) / 1.055).powf(2.4)
+        } else {
+            x / 12.92
+        }
+    };
+    [f(c >> 16), f(c >> 8), f(c)]
+}
+
+/// Linear to sRGB conversion.
+///
+/// Implementation taken from https://en.wikipedia.org/wiki/SRGB
+pub fn from_linear_rgb(c: [f32; 3]) -> Color {
+    let f = |x: f32| -> u32 {
+        let y = if x > 0.0031308 {
+            let a = 0.055;
+            (1.0 + a) * x.powf(-2.4) - a
+        } else {
+            12.92 * x
+        };
+        (y * 255.0).round() as u32
+    };
+    f(c[0]) << 16 | f(c[1]) << 8 | f(c[2])
+}

--- a/src/factory/load_gltf.rs
+++ b/src/factory/load_gltf.rs
@@ -123,7 +123,6 @@ impl super::Factory {
             material::Basic {
                 color: base_color_factor,
                 map: base_color_map,
-                pipeline: material::basic::Pipeline::Solid,
             }.into()
         } else {
             material::Pbr {

--- a/src/factory/load_gltf.rs
+++ b/src/factory/load_gltf.rs
@@ -3,6 +3,7 @@ use geometry;
 use gltf;
 use gltf_importer;
 use image;
+use material;
 use mint;
 use std::{fs, io};
 use util;
@@ -114,25 +115,31 @@ impl super::Factory {
             is_basic_material = false;
             self.load_gltf_texture(&t, buffers, base)
         });
+        let (base_color_factor, base_color_alpha) = {
+            let x = pbr.base_color_factor();
+            (util::encode_color([x[0], x[1], x[2]]), x[3])
+        };
         if is_basic_material {
-            Material::MeshBasic {
-                color: util::encode_color(pbr.base_color_factor()),
-                wireframe: false,
+            material::Basic {
+                color: base_color_factor,
                 map: base_color_map,
-            }
+                pipeline: material::basic::Pipeline::Solid,
+            }.into()
         } else {
-            Material::MeshPbr {
-                base_color_factor: pbr.base_color_factor(),
-                metallic_roughness: [pbr.metallic_factor(), pbr.roughness_factor()],
+            material::Pbr {
+                base_color_factor,
+                base_color_alpha,
+                metallic_factor: pbr.metallic_factor(),
+                roughness_factor: pbr.roughness_factor(),
                 occlusion_strength: mat.occlusion_texture().map_or(1.0, |t| t.strength()),
-                emissive_factor: mat.emissive_factor(),
+                emissive_factor: util::encode_color(mat.emissive_factor()),
                 normal_scale: mat.normal_texture().map_or(1.0, |t| t.scale()),
                 base_color_map,
                 normal_map,
                 emissive_map,
                 metallic_roughness_map,
                 occlusion_map,
-            }
+            }.into()
         }
     }
 
@@ -236,7 +243,7 @@ impl super::Factory {
                 if has_entry {
                     let mesh = meshes.get(index).unwrap();
                     for primitive in mesh.iter() {
-                        let instance = self.mesh_instance(primitive, None);
+                        let instance = self.mesh_instance(primitive);
                         item.group.add(&instance);
                         instances.push(instance);
                     }
@@ -251,18 +258,18 @@ impl super::Factory {
 
             if let Some(entry) = item.node.camera() {
                 match entry.projection() {
-                    gltf::camera::Projection::Orthographic(x) => {
+                    gltf::camera::Projection::Orthographic(values) => {
                         let center: mint::Point2<f32> = [0.0, 0.0].into();
-                        let extent_y = x.ymag();
-                        let range = x.znear() .. x.zfar();
+                        let extent_y = values.ymag();
+                        let range = values.znear() .. values.zfar();
                         let camera = self.orthographic_camera(center, extent_y, range);
                         item.group.add(&camera);
                         cameras.push(camera);
                     }
-                    gltf::camera::Projection::Perspective(x) => {
-                        let fov_y = x.yfov().to_degrees();
-                        let near = x.znear();
-                        let camera = if let Some(far) = x.zfar() {
+                    gltf::camera::Projection::Perspective(values) => {
+                        let fov_y = values.yfov().to_degrees();
+                        let near = values.znear();
+                        let camera = if let Some(far) = values.zfar() {
                             self.perspective_camera(fov_y, near .. far)
                         } else {
                             self.perspective_camera(fov_y, near ..)

--- a/src/factory/load_gltf.rs
+++ b/src/factory/load_gltf.rs
@@ -1,4 +1,5 @@
 use animation;
+use color;
 use geometry;
 use gltf;
 use gltf_importer;
@@ -6,7 +7,6 @@ use image;
 use material;
 use mint;
 use std::{fs, io};
-use util;
 
 use camera::Camera;
 use gltf::Gltf;
@@ -117,7 +117,7 @@ impl super::Factory {
         });
         let (base_color_factor, base_color_alpha) = {
             let x = pbr.base_color_factor();
-            (util::encode_color([x[0], x[1], x[2]]), x[3])
+            (color::from_linear_rgb([x[0], x[1], x[2]]), x[3])
         };
         if is_basic_material {
             material::Basic {
@@ -132,7 +132,7 @@ impl super::Factory {
                 metallic_factor: pbr.metallic_factor(),
                 roughness_factor: pbr.roughness_factor(),
                 occlusion_strength: mat.occlusion_texture().map_or(1.0, |t| t.strength()),
-                emissive_factor: util::encode_color(mat.emissive_factor()),
+                emissive_factor: color::from_linear_rgb(mat.emissive_factor()),
                 normal_scale: mat.normal_texture().map_or(1.0, |t| t.scale()),
                 base_color_map,
                 normal_map,

--- a/src/factory/mod.rs
+++ b/src/factory/mod.rs
@@ -729,14 +729,12 @@ impl Factory {
                         (true, &Some(ref name)) => Some(self.request_texture(&concat_path(obj_dir, name))),
                         _ => None,
                     },
-                    pipeline: material::basic::Pipeline::Solid,
                 }.into()
             }
             _ => {
                 material::Basic {
                     color: 0xffffff,
                     map: None,
-                    pipeline: material::basic::Pipeline::Solid,
                 }.into()
             }
         }
@@ -848,7 +846,6 @@ impl Factory {
                         material::Basic {
                             color: 0xFFFFFF,
                             map: None,
-                            pipeline: material::basic::Pipeline::Solid,
                         }.into()
                     }
                 };

--- a/src/factory/mod.rs
+++ b/src/factory/mod.rs
@@ -22,6 +22,7 @@ use render;
 
 use audio::{AudioData, Clip, Source};
 use camera::Camera;
+use color::Color;
 use geometry::{Geometry, Shape};
 use hub::{Hub, HubPtr, LightData, SubLight, SubNode};
 use light::{Ambient, Directional, Hemisphere, Point, ShadowMap};
@@ -30,7 +31,7 @@ use mesh::{DynamicMesh, Mesh};
 use node::Node;
 use object::Group;
 use render::{basic_pipe, BackendFactory, BackendResources, BasicPipelineState, DynamicData, GpuData, ShadowFormat, Vertex};
-use scene::{Background, Color, Scene, SceneId};
+use scene::{Background, Scene, SceneId};
 use sprite::Sprite;
 use text::{Font, Text, TextData};
 use texture::{CubeMap, CubeMapPath, FilterMethod, Sampler, Texture, WrapMode};

--- a/src/factory/mod.rs
+++ b/src/factory/mod.rs
@@ -15,6 +15,7 @@ use gfx::format::I8Norm;
 use gfx::traits::{Factory as Factory_, FactoryExt};
 use image;
 use itertools::Either;
+use material;
 use mint;
 use obj;
 use render;
@@ -227,10 +228,10 @@ impl Factory {
     }
 
     /// Create new `Mesh` with desired `Geometry` and `Material`.
-    pub fn mesh(
+    pub fn mesh<M: Into<Material>>(
         &mut self,
         geometry: Geometry,
-        mat: Material,
+        material: M,
     ) -> Mesh {
         let vertices = Self::mesh_vertices(&geometry.base_shape);
         let cbuf = self.backend.create_constant_buffer(1);
@@ -245,7 +246,7 @@ impl Factory {
         };
         Mesh {
             object: self.hub.lock().unwrap().spawn_visual(
-                mat,
+                material.into(),
                 GpuData {
                     slice,
                     vertices: vbuf,
@@ -257,10 +258,10 @@ impl Factory {
     }
 
     /// Create a new `DynamicMesh` with desired `Geometry` and `Material`.
-    pub fn mesh_dynamic(
+    pub fn mesh_dynamic<M: Into<Material>>(
         &mut self,
         geometry: Geometry,
-        mat: Material,
+        material: M,
     ) -> DynamicMesh {
         let slice = {
             let data: &[u32] = gfx::memory::cast_slice(&geometry.faces);
@@ -292,7 +293,7 @@ impl Factory {
 
         DynamicMesh {
             object: self.hub.lock().unwrap().spawn_visual(
-                mat,
+                material.into(),
                 GpuData {
                     slice,
                     vertices,
@@ -310,12 +311,10 @@ impl Factory {
 
     /// Create a `Mesh` sharing the geometry with another one.
     /// Rendering a sequence of meshes with the same geometry is faster.
-    ///
-    /// When `new_mat` is `None`, the material is duplicated from its template.
+    /// The material is duplicated from the template.
     pub fn mesh_instance(
         &mut self,
         template: &Mesh,
-        new_mat: Option<Material>,
     ) -> Mesh {
         let mut hub = self.hub.lock().unwrap();
         let gpu_data = match hub.nodes[&template.node].sub_node {
@@ -325,20 +324,38 @@ impl Factory {
             },
             _ => unreachable!(),
         };
-        let mat = new_mat.unwrap_or_else(|| match hub.nodes[&template.node].sub_node {
+        let material = match hub.nodes[&template.node].sub_node {
             SubNode::Visual(ref mat, _) => mat.clone(),
             _ => unreachable!(),
-        });
-        Mesh { object: hub.spawn_visual(mat, gpu_data) }
+        };
+        Mesh { object: hub.spawn_visual(material, gpu_data) }
+    }
+
+    /// Create a `Mesh` sharing the geometry with another one but with a different material.
+    /// Rendering a sequence of meshes with the same geometry is faster.
+    pub fn mesh_instance_with_material<M: Into<Material>>(
+        &mut self,
+        template: &Mesh,
+        material: M,
+    ) -> Mesh {
+        let mut hub = self.hub.lock().unwrap();
+        let gpu_data = match hub.nodes[&template.node].sub_node {
+            SubNode::Visual(_, ref gpu) => GpuData {
+                constants: self.backend.create_constant_buffer(1),
+                ..gpu.clone()
+            },
+            _ => unreachable!(),
+        };
+        Mesh { object: hub.spawn_visual(material.into(), gpu_data) }
     }
 
     /// Create new sprite from `Material`.
     pub fn sprite(
         &mut self,
-        mat: Material,
+        material: material::Sprite,
     ) -> Sprite {
         Sprite::new(self.hub.lock().unwrap().spawn_visual(
-            mat,
+            material.into(),
             GpuData {
                 slice: gfx::Slice::new_match_vertex_buffer(&self.quad_buf),
                 vertices: self.quad_buf.clone(),
@@ -689,34 +706,38 @@ impl Factory {
                 ns: Some(glossiness),
                 ..
             } if has_normals => {
-                Material::MeshPhong {
+                material::Phong {
                     color: cf2u(color),
                     glossiness,
-                }
+                }.into()
             }
             obj::Material { kd: Some(color), .. } if has_normals => {
-                Material::MeshLambert {
+                material::Lambert {
                     color: cf2u(color),
                     flat: false,
-                }
+                }.into()
             }
             obj::Material {
                 kd: Some(color),
                 ref map_kd,
                 ..
-            } => Material::MeshBasic {
-                color: cf2u(color),
-                map: match (has_uv, map_kd) {
-                    (true, &Some(ref name)) => Some(self.request_texture(&concat_path(obj_dir, name))),
-                    _ => None,
-                },
-                wireframe: false,
-            },
-            _ => Material::MeshBasic {
-                color: 0xffffff,
-                map: None,
-                wireframe: true,
-            },
+            } => {
+                material::Basic {
+                    color: cf2u(color),
+                    map: match (has_uv, map_kd) {
+                        (true, &Some(ref name)) => Some(self.request_texture(&concat_path(obj_dir, name))),
+                        _ => None,
+                    },
+                    pipeline: material::basic::Pipeline::Solid,
+                }.into()
+            }
+            _ => {
+                material::Basic {
+                    color: 0xffffff,
+                    map: None,
+                    pipeline: material::basic::Pipeline::Solid,
+                }.into()
+            }
         }
     }
 
@@ -822,11 +843,13 @@ impl Factory {
                 );
                 let material = match gr.material {
                     Some(ref rc_mat) => self.load_obj_material(&*rc_mat, num_normals != 0, num_uvs != 0, path_parent),
-                    None => Material::MeshBasic {
-                        color: 0xffffff,
-                        map: None,
-                        wireframe: true,
-                    },
+                    None => {
+                        material::Basic {
+                            color: 0xFFFFFF,
+                            map: None,
+                            pipeline: material::basic::Pipeline::Solid,
+                        }.into()
+                    }
                 };
                 info!("\t{:?}", material);
 

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -1,6 +1,6 @@
 use audio::{AudioData, Operation as AudioOperation};
 use light::{ShadowMap, ShadowProjection};
-use material::Material;
+use material::{self, Material};
 use mesh::DynamicMesh;
 use node::{Node, NodePointer};
 use object::Object;
@@ -156,8 +156,8 @@ impl Hub {
                 }
                 Operation::SetTexelRange(base, size) => {
                     if let SubNode::Visual(ref mut material, _) = node.sub_node {
-                        match *material {
-                            Material::Sprite { ref mut map } => map.set_texel_range(base, size),
+                        match &mut material.0 {
+                            &mut material::Params::Sprite(ref mut params) => params.map.set_texel_range(base, size),
                             _ => panic!("Unsupported material for texel range request"),
                         }
                     }

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -1,11 +1,11 @@
 use audio::{AudioData, Operation as AudioOperation};
+use color::{self, Color};
 use light::{ShadowMap, ShadowProjection};
 use material::{self, Material};
 use mesh::DynamicMesh;
 use node::{Node, NodePointer};
 use object::Object;
 use render::GpuData;
-use scene::Color;
 use text::{Operation as TextOperation, TextData};
 
 use cgmath::Transform;
@@ -197,10 +197,8 @@ impl Hub {
         use gfx_glyph::Scale;
         match operation {
             TextOperation::Color(color) => {
-                use util::decode_color;
-                let mut color = decode_color(color);
-                color[3] = data.section.color[3];
-                data.section.color = color;
+                let rgb = color::to_linear_rgb(color);
+                data.section.color = [rgb[0], rgb[1], rgb[2], 0.0];
             }
             TextOperation::Font(font) => data.font = font,
             TextOperation::Layout(layout) => data.layout = layout,

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -156,8 +156,8 @@ impl Hub {
                 }
                 Operation::SetTexelRange(base, size) => {
                     if let SubNode::Visual(ref mut material, _) = node.sub_node {
-                        match &mut material.0 {
-                            &mut material::Params::Sprite(ref mut params) => params.map.set_texel_range(base, size),
+                        match *material {
+                            material::Material::Sprite(ref mut params) => params.map.set_texel_range(base, size),
                             _ => panic!("Unsupported material for texel range request"),
                         }
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,6 +270,7 @@ mod macros;
 pub mod audio;
 pub mod animation;
 pub mod camera;
+pub mod color;
 pub mod controls;
 pub mod custom;
 mod data;
@@ -291,6 +292,7 @@ mod util;
 #[cfg(feature = "opengl")]
 pub mod window;
 
+pub use color::Color;
 pub use controls::{AXIS_DOWN_UP, AXIS_LEFT_RIGHT, KEY_ESCAPE, KEY_SPACE, MOUSE_LEFT, MOUSE_RIGHT};
 pub use controls::{Button, Input, KeyAxis, Timer};
 pub use factory::{Factory, Gltf};
@@ -302,7 +304,7 @@ pub use mesh::{DynamicMesh, Mesh};
 pub use node::{NodeInfo, NodePointer, NodeTransform};
 pub use object::{Group, Object};
 pub use render::Renderer;
-pub use scene::{Background, Color, Scene};
+pub use scene::{Background, Scene};
 pub use sprite::Sprite;
 pub use text::{Align, Font, Layout, Text};
 pub use texture::{CubeMap, CubeMapPath, FilterMethod, Sampler, Texture, WrapMode};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,10 +41,9 @@
 //!     [ 0.5, -0.5, -0.5].into(),
 //!     [ 0.0,  0.5, -0.5].into(),
 //! ]);
-//! let material = three::Material::MeshBasic {
+//! let material = three::material::Basic {
 //!     color: 0xFFFF00,
-//!     wireframe: false,
-//!     map: None,
+//!     .. Default::default()
 //! };
 //! let mesh = window.factory.mesh(geometry, material);
 //! # let _ = mesh;
@@ -67,10 +66,9 @@
 //! #     [ 0.0,  0.5, -0.5].into(),
 //! # ];
 //! # let geometry = three::Geometry::with_vertices(vertices);
-//! # let material = three::Material::MeshBasic {
+//! # let material = three::material::Basic {
 //! #      color: 0xFFFF00,
-//! #     wireframe: false,
-//! #     map: None,
+//! #      .. Default::default()
 //! # };
 //! # let mesh = window.factory.mesh(geometry, material);
 //! window.scene.add(&mesh);
@@ -106,10 +104,9 @@
 //! #         [ 0.0,  0.5, -0.5].into(),
 //! #     ];
 //! #     let geometry = three::Geometry::with_vertices(vertices);
-//! #     let material = three::Material::MeshBasic {
+//! #     let material = three::material::Basic {
 //! #         color: 0xFFFF00,
-//! #         wireframe: false,
-//! #         map: None,
+//! #         .. Default::default()
 //! #     };
 //! #     let mesh = window.factory.mesh(geometry, material);
 //! #     window.scene.add(&mesh);
@@ -141,10 +138,9 @@
 //!         [ 0.0,  0.5, -0.5].into(),
 //!     ];
 //!     let geometry = three::Geometry::with_vertices(vertices);
-//!     let material = three::Material::MeshBasic {
+//!     let material = three::material::Basic {
 //!         color: 0xFFFF00,
-//!         wireframe: false,
-//!         map: None,
+//!         .. Default::default()
 //!     };
 //!     let mesh = window.factory.mesh(geometry, material);
 //!     window.scene.add(&mesh);
@@ -282,7 +278,7 @@ pub mod geometry;
 mod hub;
 mod input;
 pub mod light;
-mod material;
+pub mod material;
 mod mesh;
 mod node;
 mod object;

--- a/src/material.rs
+++ b/src/material.rs
@@ -1,7 +1,7 @@
 //! Material parameters for mesh rendering.
 
+use color::Color;
 use render::BasicPipelineState;
-use scene::Color;
 use texture::Texture;
 
 pub use self::basic::Basic;

--- a/src/material.rs
+++ b/src/material.rs
@@ -1,45 +1,220 @@
+//! Material parameters for mesh rendering.
+
 use render::BasicPipelineState;
 use scene::Color;
 use texture::Texture;
 
-/// Material is the enhancement of Texture that is used to setup appearance of [`Mesh`](struct.Mesh.html).
-#[allow(missing_docs)]
-#[derive(Clone, Debug)]
-pub enum Material {
-    /// Basic wireframe with specific `Color`.
-    LineBasic { color: Color },
-    /// Basic material with color, optional `Texture` and optional wireframe mode.
-    MeshBasic {
-        color: Color,
-        map: Option<Texture<[f32; 4]>>,
-        wireframe: bool,
-    },
-    /// Lambertian diffuse reflection. This technique causes all closed polygons
-    /// (such as a triangle within a 3D mesh) to reflect light equally in all
-    /// directions when rendered.
-    MeshLambert { color: Color, flat: bool },
-    /// Material that uses Phong reflection model.
-    MeshPhong { color: Color, glossiness: f32 },
-    /// Physically-based rendering material.
-    MeshPbr {
-        base_color_factor: [f32; 4],
-        metallic_roughness: [f32; 2],
-        occlusion_strength: f32,
-        emissive_factor: [f32; 3],
-        normal_scale: f32,
+pub use self::basic::Basic;
 
-        base_color_map: Option<Texture<[f32; 4]>>,
-        normal_map: Option<Texture<[f32; 4]>>,
-        emissive_map: Option<Texture<[f32; 4]>>,
-        metallic_roughness_map: Option<Texture<[f32; 4]>>,
-        occlusion_map: Option<Texture<[f32; 4]>>,
-    },
-    /// 2D Sprite.
-    Sprite { map: Texture<[f32; 4]> },
-    /// Custom material.
-    CustomBasicPipeline {
-        color: Color,
-        map: Option<Texture<[f32; 4]>>,
-        pipeline: BasicPipelineState,
-    },
+/// Basic material parameters.
+pub mod basic {
+    use super::*;
+
+    /// Parameters for a basic mesh material.
+    #[derive(Clone, Debug, Default)]
+    pub struct Basic {
+        /// Solid color applied in the absense of `map`.
+        ///
+        /// Default: `0x000000` (black).
+        pub color: Color,
+
+        /// Texture applied using the mesh texture co-ordiantes.
+        ///
+        /// Default: `None`.
+        pub map: Option<Texture<[f32; 4]>>,
+
+        /// Specifies which pipeline should be used to render the mesh.
+        ///
+        /// Default: `Solid`.
+        pub pipeline: Pipeline,
+    }
+
+    /// Specifies which pipeline should be used to render the mesh.
+    #[derive(Clone, Debug)]
+    pub enum Pipeline {
+        /// Renders the mesh as a solid.
+        Solid,
+
+        /// Renders the mesh as a wireframe.
+        Wireframe,
+
+        /// Renders the mesh with a custom pipeline state object.
+        Custom(BasicPipelineState),
+    }
+
+    impl Default for Pipeline {
+        fn default() -> Self {
+            Pipeline::Solid
+        }
+    }
+}
+
+/// Parameters for a Lamberian diffusion reflection model.
+#[derive(Clone, Debug, Default)]
+pub struct Lambert {
+    /// Solid color applied in the absense of `map`.
+    ///
+    /// Default: `0x000000` (black).
+    pub color: Color,
+
+    /// Specifies whether lighting should be constant over faces.
+    ///
+    /// Default: `false` (lighting is interpolated across faces).
+    pub flat: bool,
+}
+
+/// Parameters for a PBR (physically based rendering) lighting model.
+#[derive(Clone, Debug)]
+pub struct Pbr {
+    /// Solid base color applied in the absense of `base_color_map`.
+    ///
+    /// Default: `0xFFFFFF` (white).
+    pub base_color_factor: Color,
+
+    /// Base color alpha factor applied in the absense of `base_color_map`.
+    ///
+    /// Default: `1.0` (opaque).
+    pub base_color_alpha: f32,
+
+    /// Metallic factor in the range [0.0, 1.0].
+    ///
+    /// Default: `1.0`.
+    pub metallic_factor: f32,
+
+    /// Roughness factor in the range [0.0, 1.0].
+    ///
+    /// * A value of 1.0 means the material is completely rough.
+    /// * A value of 0.0 means the material is completely smooth.
+    ///
+    /// Default: `1.0`.
+    pub roughness_factor: f32,
+
+    /// Scalar multiplier in the range [0.0, 1.0] that controls the amount of
+    /// occlusion applied in the presense of `occlusion_map`.
+    ///
+    /// Default: `1.0`.
+    pub occlusion_strength: f32,
+
+    /// Solid emissive color applied in the absense of `emissive_map`.
+    ///
+    /// Default: `0x000000` (black).
+    pub emissive_factor: Color,
+
+    /// Scalar multiplier applied to each normal vector of the `normal_map`.
+    ///
+    /// This value is ignored in the absense of `normal_map`.
+    ///
+    /// Default: `1.0`.
+    pub normal_scale: f32,
+
+    /// Base color texture.
+    ///
+    /// Default: `None`.
+    pub base_color_map: Option<Texture<[f32; 4]>>,
+
+    /// Normal texture.
+    ///
+    /// Default: `None`.
+    pub normal_map: Option<Texture<[f32; 4]>>,
+
+    /// Emissive texture.
+    ///
+    /// Default: `None`.
+    pub emissive_map: Option<Texture<[f32; 4]>>,
+
+    /// Metallic-roughness texture.
+    ///
+    /// Default: `None`.
+    pub metallic_roughness_map: Option<Texture<[f32; 4]>>,
+
+    /// Occlusion texture.
+    ///
+    /// Default: `None`.
+    pub occlusion_map: Option<Texture<[f32; 4]>>,
+}
+
+impl Default for Pbr {
+    fn default() -> Self {
+        Self {
+            base_color_factor: 0xFFFFFF,
+            base_color_alpha: 1.0,
+            metallic_factor: 1.0,
+            roughness_factor: 1.0,
+            occlusion_strength: 1.0,
+            emissive_factor: 0x000000,
+            normal_scale: 1.0,
+            base_color_map: None,
+            normal_map: None,
+            emissive_map: None,
+            metallic_roughness_map: None,
+            occlusion_map: None,
+        }
+    }
+}
+
+/// Parameters for a Phong reflection model.
+#[derive(Clone, Debug, Default)]
+pub struct Phong {
+    /// Solid color applied in the absense of `map`.
+    ///
+    /// Default: `0x000000` (black).
+    pub color: Color,
+
+    /// Determines the sharpness of specular highlights.
+    ///
+    /// Higher values result in sharper highlights to produce a glossy effect.
+    ///
+    /// Default: `30.0`.
+    pub glossiness: f32,
+}
+
+/// Texture for a 2D sprite.
+#[derive(Clone, Debug)]
+pub struct Sprite {
+    /// The texture the apply to the sprite.
+    pub map: Texture<[f32; 4]>,
+}
+
+/// Specifies the appearance of a [`Mesh`](struct.Mesh.html).
+#[derive(Clone, Debug)]
+pub struct Material(pub(crate) Params);
+
+/// Internal material parameters.
+#[derive(Clone, Debug)]
+pub(crate) enum Params {
+    Basic(Basic),
+    Lambert(Lambert),
+    Phong(Phong),
+    Pbr(Pbr),
+    Sprite(Sprite),
+}
+
+impl From<Basic> for Material {
+    fn from(params: Basic) -> Material {
+        Material(Params::Basic(params))
+    }
+}
+
+impl From<Lambert> for Material {
+    fn from(params: Lambert) -> Material {
+        Material(Params::Lambert(params))
+    }
+}
+
+impl From<Phong> for Material {
+    fn from(params: Phong) -> Material {
+        Material(Params::Phong(params))
+    }
+}
+
+impl From<Pbr> for Material {
+    fn from(params: Pbr) -> Material {
+        Material(Params::Pbr(params))
+    }
+}
+
+impl From<Sprite> for Material {
+    fn from(params: Sprite) -> Material {
+        Material(Params::Sprite(params))
+    }
 }

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -8,7 +8,7 @@ use render::DynamicData;
 ///
 /// # Examples
 ///
-/// Creating a red triangle.
+/// Creating a solid red triangle.
 ///
 /// ```rust,no_run
 /// # let mut win = three::Window::new("Example");
@@ -19,10 +19,10 @@ use render::DynamicData;
 ///     [ 0.5, -0.5, 0.0].into(),
 /// ];
 /// let geometry = three::Geometry::with_vertices(vertices);
-/// let red_material = three::Material::MeshBasic {
+/// let red_material = three::material::Basic {
 ///     color: 0xFF0000,
-///     wireframe: false,
 ///     map: None,
+///     pipeline: three::material::basic::Pipeline::Solid,
 /// };
 /// let mesh = factory.mesh(geometry, red_material);
 /// # let _ = mesh;
@@ -39,23 +39,42 @@ use render::DynamicData;
 /// #     [ 0.5, -0.5, 0.0].into(),
 /// # ];
 /// # let geometry = three::Geometry::with_vertices(vertices);
-/// # let red_material = three::Material::MeshBasic {
+/// # let red_material = three::material::Basic {
 /// #     color: 0xFF0000,
-/// #     wireframe: false,
 /// #     map: None,
+/// #     pipeline: three::material::basic::Pipeline::Solid,
 /// # };
 /// # let mesh = factory.mesh(geometry, red_material);
-/// let yellow_material = three::Material::MeshBasic {
-///    color: 0xFFFF00,
-///    wireframe: false,
-///    map: None,
-/// };
-/// let mut duplicate = factory.mesh_instance(&mesh, Some(yellow_material));
-/// // Duplicated meshes share their geometry but can be transformed individually
-/// // and be rendered with different materials.
+/// let mut duplicate = factory.mesh_instance(&mesh);
+/// // Duplicated meshes share their geometry but may be transformed individually.
 /// duplicate.set_position([1.2, 3.4, 5.6]);
 /// ```
 ///
+/// Duplicating a mesh with a different material.
+///
+/// ```rust,no_run
+/// # let mut win = three::Window::new("Example");
+/// # let factory = &mut win.factory;
+/// # let vertices = vec![
+/// #     [-0.5, -0.5, 0.0].into(),
+/// #     [ 0.5, -0.5, 0.0].into(),
+/// #     [ 0.5, -0.5, 0.0].into(),
+/// # ];
+/// # let geometry = three::Geometry::with_vertices(vertices);
+/// # let red_material = three::material::Basic {
+/// #     color: 0xFF0000,
+/// #     map: None,
+/// #     pipeline: three::material::basic::Pipeline::Solid,
+/// # };
+/// # let mesh = factory.mesh(geometry, red_material);
+/// let yellow_material = three::material::Basic {
+///     color: 0xFFFF00,
+///     map: None,
+///     pipeline: three::material::basic::Pipeline::Wireframe,
+/// };
+/// let mut duplicate = factory.mesh_instance_with_material(&mesh, yellow_material);
+/// duplicate.set_position([1.2, 3.4, 5.6]);
+/// ```
 /// # Notes
 ///
 /// * Meshes are removed from the scene when dropped.

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -19,11 +19,7 @@ use render::DynamicData;
 ///     [ 0.5, -0.5, 0.0].into(),
 /// ];
 /// let geometry = three::Geometry::with_vertices(vertices);
-/// let red_material = three::material::Basic {
-///     color: 0xFF0000,
-///     map: None,
-///     pipeline: three::material::basic::Pipeline::Solid,
-/// };
+/// let red_material = three::material::Basic { color: three::color::RED, map: None };
 /// let mesh = factory.mesh(geometry, red_material);
 /// # let _ = mesh;
 /// ```
@@ -39,11 +35,7 @@ use render::DynamicData;
 /// #     [ 0.5, -0.5, 0.0].into(),
 /// # ];
 /// # let geometry = three::Geometry::with_vertices(vertices);
-/// # let red_material = three::material::Basic {
-/// #     color: 0xFF0000,
-/// #     map: None,
-/// #     pipeline: three::material::basic::Pipeline::Solid,
-/// # };
+/// # let red_material = three::material::Basic { color: three::color::RED, map: None };
 /// # let mesh = factory.mesh(geometry, red_material);
 /// let mut duplicate = factory.mesh_instance(&mesh);
 /// // Duplicated meshes share their geometry but may be transformed individually.
@@ -61,20 +53,13 @@ use render::DynamicData;
 /// #     [ 0.5, -0.5, 0.0].into(),
 /// # ];
 /// # let geometry = three::Geometry::with_vertices(vertices);
-/// # let red_material = three::material::Basic {
-/// #     color: 0xFF0000,
-/// #     map: None,
-/// #     pipeline: three::material::basic::Pipeline::Solid,
-/// # };
+/// # let red_material = three::material::Basic { color: three::color::RED, map: None };
 /// # let mesh = factory.mesh(geometry, red_material);
-/// let yellow_material = three::material::Basic {
-///     color: 0xFFFF00,
-///     map: None,
-///     pipeline: three::material::basic::Pipeline::Wireframe,
-/// };
+/// let yellow_material = three::material::Wireframe { color: three::color::YELLOW };
 /// let mut duplicate = factory.mesh_instance_with_material(&mesh, yellow_material);
 /// duplicate.set_position([1.2, 3.4, 5.6]);
 /// ```
+///
 /// # Notes
 ///
 /// * Meshes are removed from the scene when dropped.

--- a/src/render/source.rs
+++ b/src/render/source.rs
@@ -29,15 +29,15 @@ impl Source {
             if line.starts_with("#include") {
                 if let Some(arg) = line.split_whitespace().skip(1).next() {
                     if arg.starts_with('<') {
-                        if let Some(pos) = arg[1..].find('>') {
-                            let name = &arg[1..(pos + 1)];
+                        if let Some(pos) = arg[1 ..].find('>') {
+                            let name = &arg[1 .. (pos + 1)];
                             let path = format!("data/shaders/{}.glsl", name);
                             let content = &data::FILES.get(&path).unwrap();
                             new_code += str::from_utf8(content.borrow()).unwrap();
                         }
                     } else if arg.starts_with('"') {
-                        if let Some(pos) = arg[1..].find('"') {
-                            let relative_path = &arg[1..(pos + 1)];
+                        if let Some(pos) = arg[1 ..].find('"') {
+                            let relative_path = &arg[1 .. (pos + 1)];
                             let path = root.join(relative_path);
                             let content = util::read_file_to_string(&path)?;
                             let include = Self::preprocess(root, &content)?;

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -1,10 +1,9 @@
+
+use color::Color;
 use hub::{HubPtr, Message, Operation};
 use node::NodePointer;
 use std::sync::mpsc;
 use texture::{CubeMap, Texture};
-
-/// Color represented by 4-bytes hex number.
-pub type Color = u32;
 
 pub type SceneId = usize;
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -8,10 +8,10 @@ use gfx::handle::RenderTargetView;
 use gfx_glyph as g;
 use mint;
 
+use color::Color;
 use hub::Operation as HubOperation;
 use object::Object;
 use render::{BackendCommandBuffer, BackendFactory, BackendResources, ColorFormat};
-use scene::Color;
 
 pub(crate) enum Operation {
     Text(String),

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,7 +18,7 @@ pub fn decode_color(c: Color) -> [f32; 4] {
 }
 
 /// Linear to sRGB conversion from https://en.wikipedia.org/wiki/SRGB
-pub fn encode_color(c: [f32; 4]) -> u32 {
+pub fn encode_color(c: [f32; 3]) -> u32 {
     let f = |x: f32| -> u32 {
         let y = if x > 0.0031308 {
             let a = 0.055;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,35 +1,6 @@
 //! Internal utility functions.
 
-use Color;
 use std::{fs, io, path};
-
-/// sRGB to linear conversion from:
-/// https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_texture_sRGB_decode.txt
-pub fn decode_color(c: Color) -> [f32; 4] {
-    let f = |xu: u32| {
-        let x = (xu & 0xFF) as f32 / 255.0;
-        if x > 0.04045 {
-            ((x + 0.055) / 1.055).powf(2.4)
-        } else {
-            x / 12.92
-        }
-    };
-    [f(c >> 16), f(c >> 8), f(c), 0.0]
-}
-
-/// Linear to sRGB conversion from https://en.wikipedia.org/wiki/SRGB
-pub fn encode_color(c: [f32; 3]) -> u32 {
-    let f = |x: f32| -> u32 {
-        let y = if x > 0.0031308 {
-            let a = 0.055;
-            (1.0 + a) * x.powf(-2.4) - a
-        } else {
-            12.92 * x
-        };
-        (y * 255.0).round() as u32
-    };
-    f(c[0]) << 16 | f(c[1]) << 8 | f(c[2])
-}
 
 /// Reads the entire contents of a file into a `String`.
 pub fn read_file_to_string<P: AsRef<path::Path>>(path: P) -> io::Result<String> {


### PR DESCRIPTION
In response to #105 , this PR changes the way materials are specified.

* There are explicit data structures for each of the pipelines.
~~* The `LineBasic` material and its implementation has been removed.~~
~~* Hence, only mesh materials will be supported.~~
* There are explicit pipelines `Basic`, `basic::Custom`, and `Wireframe`.