### PR TITLE
 Make key axis deltas continuous instead of discrete 

### DIFF
--- a/src/controls/first_person.rs
+++ b/src/controls/first_person.rs
@@ -339,9 +339,7 @@ impl FirstPerson {
         &mut self,
         input: &Input,
     ) {
-        let dtime = input.delta_time();
-        let dlook = dtime * self.look_speed;
-
+        let dlook = input.delta_time() * self.look_speed;
         let mouse = input.mouse_delta_raw();
 
         self.yaw += dlook * mouse.x;
@@ -360,7 +358,7 @@ impl FirstPerson {
         self.axes
             .vertical
             .map(|a| if let Some(diff) = input.timed(a) {
-                self.position.y += self.move_speed * diff * dtime;
+                self.position.y += self.move_speed * diff;
             });
 
         self.axes


### PR DESCRIPTION
Fixes unwanted 'jagged' input behaviour. This most notably affects the first person camera controls.

#### Behaviour before fix

Frame | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
Event | - | P | - | - | - | P | P | R | - | -
Move | N | Y | N | N | N | Y | Y | N | N | N

#### Behaviour after fix

Frame | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
Event | - | P | - | - | - | P | P | R | - | -
Move | N | Y | Y | Y | Y | Y | Y | N | N | N
