### PR TITLE
Get rid of Node and NodePointer types

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -60,7 +60,7 @@ use cgmath;
 use mint;
 use std::ops;
 
-use NodePointer;
+use node::NodePointer;
 use object::Object;
 
 /// The Z values of the near and far clipping planes of a camera's projection.

--- a/src/controls/orbit.rs
+++ b/src/controls/orbit.rs
@@ -3,7 +3,7 @@ use cgmath::{EuclideanSpace, InnerSpace, Rotation, Rotation3, Transform as Trans
 use mint;
 
 use input::{Button, Input, MOUSE_LEFT};
-use node::Transform;
+use node::TransformInternal;
 use object::Object;
 
 /// Simple controls for Orbital Camera.
@@ -13,7 +13,7 @@ use object::Object;
 /// to adjust distance to the central point.
 pub struct Orbit {
     object: Object,
-    transform: Transform,
+    transform: TransformInternal,
     target: Point3<f32>,
     button: Button,
     speed: f32,

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -3,7 +3,7 @@ use color::{self, Color};
 use light::{ShadowMap, ShadowProjection};
 use material::{self, Material};
 use mesh::DynamicMesh;
-use node::{Node, NodePointer};
+use node::{NodeInternal, NodePointer};
 use object::Object;
 use render::GpuData;
 use text::{Operation as TextOperation, TextData};
@@ -48,7 +48,7 @@ pub(crate) enum SubNode {
     Scene,
 }
 
-pub(crate) type Message = (froggy::WeakPointer<Node>, Operation);
+pub(crate) type Message = (froggy::WeakPointer<NodeInternal>, Operation);
 pub(crate) enum Operation {
     SetAudio(AudioOperation),
     SetParent(NodePointer),
@@ -67,7 +67,7 @@ pub(crate) enum Operation {
 pub(crate) type HubPtr = Arc<Mutex<Hub>>;
 
 pub(crate) struct Hub {
-    pub(crate) nodes: froggy::Storage<Node>,
+    pub(crate) nodes: froggy::Storage<NodeInternal>,
     pub(crate) message_tx: mpsc::Sender<Message>,
     message_rx: mpsc::Receiver<Message>,
 }
@@ -130,7 +130,7 @@ impl Hub {
         static SCENE_UID_COUNTER: atomic::AtomicUsize = atomic::ATOMIC_USIZE_INIT;
         let uid = SCENE_UID_COUNTER.fetch_add(1, atomic::Ordering::Relaxed);
         let tx = self.message_tx.clone();
-        let node = self.nodes.create(Node {
+        let node = self.nodes.create(NodeInternal {
             scene_id: Some(uid),
             .. SubNode::Scene.into()
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,7 +300,7 @@ pub use geometry::Geometry;
 pub use glutin::VirtualKeyCode as Key;
 pub use material::Material;
 pub use mesh::{DynamicMesh, Mesh};
-pub use node::{NodeInfo, NodePointer, NodeTransform};
+pub use node::{Node, Transform};
 pub use object::{Group, Object};
 pub use render::Renderer;
 pub use scene::{Background, Scene};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -3,7 +3,6 @@
 ///
 /// Implements the following traits:
 ///
-/// * `AsRef<NodePointer>`
 /// * `Deref<Target=Object>`
 /// * `DerefMut<Object>`
 ///
@@ -44,12 +43,6 @@ macro_rules! three_object_wrapper {
     };
     ($($name:ident::$field:ident),*) => {
         $(
-            impl AsRef<$crate::NodePointer> for $name {
-                fn as_ref(&self) -> &$crate::NodePointer {
-                    self.$field.as_ref()
-                }
-            }
-
             impl ::std::ops::Deref for $name {
                 type Target = $crate::Object;
                 fn deref(&self) -> &$crate::Object {

--- a/src/node.rs
+++ b/src/node.rs
@@ -7,23 +7,23 @@ use hub::SubNode;
 use material::Material;
 
 /// Pointer to a Node
-pub type NodePointer = froggy::Pointer<Node>;
-pub(crate) type Transform = cgmath::Decomposed<cgmath::Vector3<f32>, cgmath::Quaternion<f32>>;
+pub(crate) type NodePointer = froggy::Pointer<NodeInternal>;
+pub(crate) type TransformInternal = cgmath::Decomposed<cgmath::Vector3<f32>, cgmath::Quaternion<f32>>;
 
-/// Fat node of the scene graph.
-///
-/// `Node` is used by `three-rs` internally,
-/// client code uses [`Object`](struct.Object.html) instead.
+// Fat node of the scene graph.
+//
+// `Node` is used by `three-rs` internally,
+// client code uses [`Object`](struct.Object.html) instead.
 #[derive(Debug)]
-pub struct Node {
+pub(crate) struct NodeInternal {
     /// `true` if this node (and its subnodes) are visible to cameras.
     pub(crate) visible: bool,
     /// For internal use.
     pub(crate) world_visible: bool,
     /// The transform relative to the node's parent.
-    pub(crate) transform: Transform,
+    pub(crate) transform: TransformInternal,
     /// The transform relative to the world origin.
-    pub(crate) world_transform: Transform,
+    pub(crate) world_transform: TransformInternal,
     /// Pointer to node's parent.
     pub(crate) parent: Option<NodePointer>,
     /// The ID of the scene this node belongs to.
@@ -32,9 +32,9 @@ pub struct Node {
     pub(crate) sub_node: SubNode,
 }
 
-/// Position, rotation, and scale of the scene [`Node`](struct.Node.html).
+/// Position, rotation, and scale of the scene `Node`.
 #[derive(Clone, Debug)]
-pub struct NodeTransform {
+pub struct Transform {
     /// Position.
     pub position: mint::Point3<f32>,
     /// Orientation.
@@ -43,10 +43,10 @@ pub struct NodeTransform {
     pub scale: f32,
 }
 
-impl From<Transform> for NodeTransform {
-    fn from(tf: Transform) -> Self {
+impl From<TransformInternal> for Transform {
+    fn from(tf: TransformInternal) -> Self {
         let pos: mint::Vector3<f32> = tf.disp.into();
-        NodeTransform {
+        Transform {
             position: pos.into(),
             orientation: tf.rot.into(),
             scale: tf.scale,
@@ -54,13 +54,13 @@ impl From<Transform> for NodeTransform {
     }
 }
 
-/// General information about scene [`Node`](struct.Node.html).
+/// General information about scene `Node`.
 #[derive(Clone, Debug)]
-pub struct NodeInfo {
+pub struct Node {
     /// Relative to parent transform.
-    pub transform: NodeTransform,
+    pub transform: Transform,
     /// World transform (relative to the world's origin).
-    pub world_transform: NodeTransform,
+    pub world_transform: Transform,
     /// Is `Node` visible by cameras or not?
     pub visible: bool,
     /// The same as `visible`, used internally.
@@ -69,9 +69,9 @@ pub struct NodeInfo {
     pub material: Option<Material>,
 }
 
-impl From<SubNode> for Node {
+impl From<SubNode> for NodeInternal {
     fn from(sub: SubNode) -> Self {
-        Node {
+        NodeInternal {
             visible: true,
             world_visible: false,
             transform: cgmath::Transform::one(),

--- a/src/text.rs
+++ b/src/text.rs
@@ -170,7 +170,7 @@ impl Text {
         text: S,
     ) {
         let msg = HubOperation::SetText(Operation::Text(text.into()));
-        let _ = self.object.tx.send((self.as_ref().downgrade(), msg));
+        let _ = self.object.tx.send((self.object.as_ref().downgrade(), msg));
     }
 
     /// Change font.
@@ -179,7 +179,7 @@ impl Text {
         font: &Font,
     ) {
         let msg = HubOperation::SetText(Operation::Font(font.clone()));
-        let _ = self.object.tx.send((self.as_ref().downgrade(), msg));
+        let _ = self.object.tx.send((self.object.as_ref().downgrade(), msg));
     }
 
     /// Change text position.
@@ -190,7 +190,7 @@ impl Text {
         point: P,
     ) {
         let msg = HubOperation::SetText(Operation::Pos(point.into()));
-        let _ = self.object.tx.send((self.as_ref().downgrade(), msg));
+        let _ = self.object.tx.send((self.object.as_ref().downgrade(), msg));
     }
 
     /// Change maximum bounds size, in pixels from top-left.
@@ -200,7 +200,7 @@ impl Text {
         dimensions: V,
     ) {
         let msg = HubOperation::SetText(Operation::Size(dimensions.into()));
-        let _ = self.object.tx.send((self.as_ref().downgrade(), msg));
+        let _ = self.object.tx.send((self.object.as_ref().downgrade(), msg));
     }
 
     /// Change text color.
@@ -210,7 +210,7 @@ impl Text {
         color: Color,
     ) {
         let msg = HubOperation::SetText(Operation::Color(color));
-        let _ = self.object.tx.send((self.as_ref().downgrade(), msg));
+        let _ = self.object.tx.send((self.object.as_ref().downgrade(), msg));
     }
 
     /// Change text opacity.
@@ -221,7 +221,7 @@ impl Text {
         opacity: f32,
     ) {
         let msg = HubOperation::SetText(Operation::Opacity(opacity));
-        let _ = self.object.tx.send((self.as_ref().downgrade(), msg));
+        let _ = self.object.tx.send((self.object.as_ref().downgrade(), msg));
     }
 
     /// Change font size (scale).
@@ -231,7 +231,7 @@ impl Text {
         size: f32,
     ) {
         let msg = HubOperation::SetText(Operation::Scale(size));
-        let _ = self.object.tx.send((self.as_ref().downgrade(), msg));
+        let _ = self.object.tx.send((self.object.as_ref().downgrade(), msg));
     }
 
     /// Change text layout.
@@ -241,6 +241,6 @@ impl Text {
         layout: Layout,
     ) {
         let msg = HubOperation::SetText(Operation::Layout(layout));
-        let _ = self.object.tx.send((self.as_ref().downgrade(), msg));
+        let _ = self.object.tx.send((self.object.as_ref().downgrade(), msg));
     }
 }


### PR DESCRIPTION
Also renamed other types:
NodeInfo -> Node
NodeTransform -> Transform