### PR TITLE
Silence deprecated warning for get_default_endpoints

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -93,6 +93,8 @@ pub(crate) struct AudioData {
 
 impl AudioData {
     pub(crate) fn new() -> Self {
+        // TODO: Change to `r::default_endpoint()` in next `rodio` release.
+        #[allow(deprecated)]
         let endpoint = if let Some(endpoint) = r::get_default_endpoint() {
             endpoint
         } else {


### PR DESCRIPTION
Temporary fix for #139. We must remember to change the function to `default_endpoints` when the next `rodio` version is released.