### PR TITLE
Auto instancing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ includedir_codegen = "0.2.0"
 
 [dependencies]
 bitflags = "0.9"
-byteorder = "1.2"
 cgmath = { version = "0.15", features = ["mint"] }
 derivative = "1.0"
 froggy = "0.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,9 @@ includedir_codegen = "0.2.0"
 
 [dependencies]
 bitflags = "0.9"
+byteorder = "1.2"
 cgmath = { version = "0.15", features = ["mint"] }
+derivative = "1.0"
 froggy = "0.4.4"
 genmesh = "0.5"
 gfx = "0.16"

--- a/data/shaders/basic_ps.glsl
+++ b/data/shaders/basic_ps.glsl
@@ -1,11 +1,11 @@
 #version 150 core
-#include <locals>
 
 in vec2 v_TexCoord;
+in vec4 v_Color;
 out vec4 Target0;
 
 uniform sampler2D t_Map;
 
 void main() {
-    Target0 = u_Color * texture(t_Map, v_TexCoord);
+    Target0 = v_Color * texture(t_Map, v_TexCoord);
 }

--- a/data/shaders/basic_vs.glsl
+++ b/data/shaders/basic_vs.glsl
@@ -1,13 +1,22 @@
 #version 150 core
-#include <locals>
 #include <globals>
 
 in vec4 a_Position;
 in vec4 a_Normal;
 in vec2 a_TexCoord;
 out vec2 v_TexCoord;
+out vec4 v_Color;
+
+in vec4 i_World0;
+in vec4 i_World1;
+in vec4 i_World2;
+in vec4 i_World3;
+in vec4 i_Color;
+in vec4 i_UvRange;
 
 void main() {
-    v_TexCoord = mix(u_UvRange.xy, u_UvRange.zw, a_TexCoord);
-    gl_Position = u_ViewProj * u_World * a_Position;
+    mat4 m_World = mat4(i_World0, i_World1, i_World2, i_World3);
+    v_TexCoord = mix(i_UvRange.xy, i_UvRange.zw, a_TexCoord);
+    v_Color = i_Color;
+    gl_Position = u_ViewProj * m_World * a_Position;
 }

--- a/data/shaders/basic_vs.glsl
+++ b/data/shaders/basic_vs.glsl
@@ -10,12 +10,11 @@ out vec4 v_Color;
 in vec4 i_World0;
 in vec4 i_World1;
 in vec4 i_World2;
-in vec4 i_World3;
 in vec4 i_Color;
 in vec4 i_UvRange;
 
 void main() {
-    mat4 m_World = mat4(i_World0, i_World1, i_World2, i_World3);
+    mat4 m_World = transpose(mat4(i_World0, i_World1, i_World2, vec4(0.0, 0.0, 0.0, 1.0)));
     v_TexCoord = mix(i_UvRange.xy, i_UvRange.zw, a_TexCoord);
     v_Color = i_Color;
     gl_Position = u_ViewProj * m_World * a_Position;

--- a/data/shaders/gouraud_vs.glsl
+++ b/data/shaders/gouraud_vs.glsl
@@ -16,13 +16,12 @@ out vec4 v_ShadowCoord[MAX_SHADOWS];
 in vec4 i_World0;
 in vec4 i_World1;
 in vec4 i_World2;
-in vec4 i_World3;
 in vec4 i_MatParams;
 in vec4 i_Color;
 in vec4 i_UvRange;
 
 void main() {
-    mat4 m_World = mat4(i_World0, i_World1, i_World2, i_World3);
+    mat4 m_World = transpose(mat4(i_World0, i_World1, i_World2, vec4(0.0, 0.0, 0.0, 1.0)));
     vec4 world = m_World * a_Position;
     vec3 normal = normalize(mat3(m_World) * a_Normal.xyz);
     for(int i=0; i<MAX_SHADOWS; ++i) {

--- a/data/shaders/gouraud_vs.glsl
+++ b/data/shaders/gouraud_vs.glsl
@@ -1,5 +1,4 @@
 #version 150 core
-#include <locals>
 #include <lights>
 #include <globals>
 
@@ -14,15 +13,24 @@ out vec4 v_LightEval[MAX_SHADOWS];
 flat out vec4 v_LightEvalFlat[MAX_SHADOWS];
 out vec4 v_ShadowCoord[MAX_SHADOWS];
 
+in vec4 i_World0;
+in vec4 i_World1;
+in vec4 i_World2;
+in vec4 i_World3;
+in vec4 i_MatParams;
+in vec4 i_Color;
+in vec4 i_UvRange;
+
 void main() {
-    vec4 world = u_World * a_Position;
-    vec3 normal = normalize(mat3(u_World) * a_Normal.xyz);
+    mat4 m_World = mat4(i_World0, i_World1, i_World2, i_World3);
+    vec4 world = m_World * a_Position;
+    vec3 normal = normalize(mat3(m_World) * a_Normal.xyz);
     for(int i=0; i<MAX_SHADOWS; ++i) {
         v_ShadowCoord[i] = vec4(0.0);
         v_LightEval[i] = v_LightEvalFlat[i] = vec4(0.0);
     }
     v_ResultColor = vec4(0.0);
-    v_Smooth = u_MatParams.x;
+    v_Smooth = i_MatParams.x;
 
     for(uint i=0U; i < min(MAX_LIGHTS, u_NumLights); ++i) {
         Light light = u_Lights[i];
@@ -34,8 +42,8 @@ void main() {
             irradiance = mix(light.color_back, light.color, dot_nl*0.5 + 0.5);
             dot_nl = 0.0;
         }
-        v_ResultColor += light.intensity.x * u_Color * irradiance; //ambient
-        vec4 color = light.intensity.y * max(0.0, dot_nl) * u_Color * light.color;
+        v_ResultColor += light.intensity.x * i_Color * irradiance; //ambient
+        vec4 color = light.intensity.y * max(0.0, dot_nl) * i_Color * light.color;
         // compute shadow coordinates
         int shadow_index = light.shadow_params[0];
         if (0 <= shadow_index && shadow_index < MAX_SHADOWS) {

--- a/data/shaders/locals.glsl
+++ b/data/shaders/locals.glsl
@@ -1,6 +1,0 @@
-uniform b_Locals {
-    mat4 u_World;
-    vec4 u_Color;
-    vec4 u_MatParams;
-    vec4 u_UvRange;
-};

--- a/data/shaders/pbr_ps.glsl
+++ b/data/shaders/pbr_ps.glsl
@@ -21,7 +21,6 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #version 150 core
-#include <locals>
 #include <lights>
 #include <globals>
 

--- a/data/shaders/pbr_vs.glsl
+++ b/data/shaders/pbr_vs.glsl
@@ -21,7 +21,6 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #version 150 core
-#include <locals>
 #include <globals>
 
 in vec4 a_Position;
@@ -34,10 +33,19 @@ out vec2 v_TexCoord;
 out mat3 v_Tbn;
 out vec3 v_Normal;
 
+in vec4 i_World0;
+in vec4 i_World1;
+in vec4 i_World2;
+in vec4 i_World3;
+in vec4 i_MatParams;
+in vec4 i_Color;
+in vec4 i_UvRange;
+
 void main()
 {
-    mat4 u_Model = u_World;
-    mat4 u_Mvp = u_ViewProj * u_World;
+    mat4 m_World = mat4(i_World0, i_World1, i_World2, i_World3);
+    mat4 u_Model = m_World;
+    mat4 u_Mvp = u_ViewProj * m_World;
 
     vec4 position = u_Model * a_Position;
     vec3 normal = normalize(vec3(u_Model * vec4(a_Normal.xyz, 0.0)));

--- a/data/shaders/pbr_vs.glsl
+++ b/data/shaders/pbr_vs.glsl
@@ -36,14 +36,13 @@ out vec3 v_Normal;
 in vec4 i_World0;
 in vec4 i_World1;
 in vec4 i_World2;
-in vec4 i_World3;
 in vec4 i_MatParams;
 in vec4 i_Color;
 in vec4 i_UvRange;
 
 void main()
 {
-    mat4 m_World = mat4(i_World0, i_World1, i_World2, i_World3);
+    mat4 m_World = transpose(mat4(i_World0, i_World1, i_World2, vec4(0.0, 0.0, 0.0, 1.0)));
     mat4 u_Model = m_World;
     mat4 u_Mvp = u_ViewProj * m_World;
 

--- a/data/shaders/phong_ps.glsl
+++ b/data/shaders/phong_ps.glsl
@@ -1,5 +1,4 @@
 #version 150 core
-#include <locals>
 #include <lights>
 #include <globals>
 
@@ -7,6 +6,9 @@ in vec3 v_World;
 in vec3 v_Normal;
 in vec3 v_Half[MAX_LIGHTS];
 in vec4 v_ShadowCoord[MAX_LIGHTS];
+
+in vec4 v_MatParams;
+in vec4 v_Color;
 
 out vec4 Target0;
 
@@ -16,7 +18,7 @@ uniform sampler2DShadow t_Shadow1;
 void main() {
     vec4 color = vec4(0.0);
     vec3 normal = normalize(v_Normal);
-    float glossiness = u_MatParams.x;
+    float glossiness = v_MatParams.x;
     for(uint i=0U; i < min(MAX_LIGHTS, u_NumLights); ++i) {
         Light light = u_Lights[i];
         vec4 lit_space = v_ShadowCoord[i];
@@ -35,10 +37,10 @@ void main() {
         // hemisphere light test
         if (dot(light.color_back, light.color_back) > 0.0) {
             vec4 irradiance = mix(light.color_back, light.color, dot_nl*0.5 + 0.5);
-            color += shadow * light.intensity.x * u_Color * irradiance;
+            color += shadow * light.intensity.x * v_Color * irradiance;
         } else {
             float kd = light.intensity.x + light.intensity.y * max(0.0, dot_nl);
-            color += shadow * kd * u_Color * light.color;
+            color += shadow * kd * v_Color * light.color;
         }
         if (dot_nl > 0.0 && glossiness > 0.0) {
             float ks = dot(normal, normalize(v_Half[i]));

--- a/data/shaders/phong_vs.glsl
+++ b/data/shaders/phong_vs.glsl
@@ -1,5 +1,4 @@
 #version 150 core
-#include <locals>
 #include <lights>
 #include <globals>
 
@@ -9,16 +8,28 @@ out vec3 v_World;
 out vec3 v_Normal;
 out vec3 v_Half[MAX_LIGHTS];
 out vec4 v_ShadowCoord[MAX_LIGHTS];
+out vec4 v_MatParams;
+out vec4 v_Color;
+
+in vec4 i_World0;
+in vec4 i_World1;
+in vec4 i_World2;
+in vec4 i_World3;
+in vec4 i_MatParams;
+in vec4 i_Color;
 
 void main() {
-    vec4 world = u_World * a_Position;
+    mat4 m_World = mat4(i_World0, i_World1, i_World2, i_World3);
+    vec4 world = m_World * a_Position;
     v_World = world.xyz;
-    v_Normal = normalize(mat3(u_World) * a_Normal.xyz);
+    v_Normal = normalize(mat3(m_World) * a_Normal.xyz);
     for(uint i=0U; i < min(MAX_LIGHTS, u_NumLights); ++i) {
         Light light = u_Lights[i];
         vec3 dir = light.pos.xyz - light.pos.w * world.xyz;
         v_Half[i] = normalize(v_Normal + normalize(dir));
         v_ShadowCoord[i] = light.projection * world;
     }
+    v_Color = i_Color;
+    v_MatParams = i_MatParams;
     gl_Position = u_ViewProj * world;
 }

--- a/data/shaders/phong_vs.glsl
+++ b/data/shaders/phong_vs.glsl
@@ -14,12 +14,11 @@ out vec4 v_Color;
 in vec4 i_World0;
 in vec4 i_World1;
 in vec4 i_World2;
-in vec4 i_World3;
 in vec4 i_MatParams;
 in vec4 i_Color;
 
 void main() {
-    mat4 m_World = mat4(i_World0, i_World1, i_World2, i_World3);
+    mat4 m_World = transpose(mat4(i_World0, i_World1, i_World2, vec4(0.0, 0.0, 0.0, 1.0)));
     vec4 world = m_World * a_Position;
     v_World = world.xyz;
     v_Normal = normalize(mat3(m_World) * a_Normal.xyz);

--- a/data/shaders/shadow_vs.glsl
+++ b/data/shaders/shadow_vs.glsl
@@ -1,9 +1,13 @@
 #version 150 core
-#include <locals>
 #include <globals>
 
 in vec4 a_Position;
+in vec4 i_World0;
+in vec4 i_World1;
+in vec4 i_World2;
+in vec4 i_World3;
 
 void main() {
-    gl_Position = u_ViewProj * u_World * a_Position;
+    mat4 m_World = mat4(i_World0, i_World1, i_World2, i_World3);
+    gl_Position = u_ViewProj * m_World * a_Position;
 }

--- a/data/shaders/shadow_vs.glsl
+++ b/data/shaders/shadow_vs.glsl
@@ -5,9 +5,8 @@ in vec4 a_Position;
 in vec4 i_World0;
 in vec4 i_World1;
 in vec4 i_World2;
-in vec4 i_World3;
 
 void main() {
-    mat4 m_World = mat4(i_World0, i_World1, i_World2, i_World3);
+    mat4 m_World = transpose(mat4(i_World0, i_World1, i_World2, vec4(0.0, 0.0, 0.0, 1.0)));
     gl_Position = u_ViewProj * m_World * a_Position;
 }

--- a/data/shaders/sprite_vs.glsl
+++ b/data/shaders/sprite_vs.glsl
@@ -1,12 +1,17 @@
 #version 150 core
-#include <locals>
 #include <globals>
 
 in vec4 a_Position;
 in vec2 a_TexCoord;
 out vec2 v_TexCoord;
+in vec4 i_World0;
+in vec4 i_World1;
+in vec4 i_World2;
+in vec4 i_World3;
+in vec4 i_UvRange;
 
 void main() {
-    v_TexCoord = mix(u_UvRange.xy, u_UvRange.zw, a_TexCoord);
-    gl_Position = u_ViewProj * u_World * a_Position;
+    mat4 m_World = mat4(i_World0, i_World1, i_World2, i_World3);
+    v_TexCoord = mix(i_UvRange.xy, i_UvRange.zw, a_TexCoord);
+    gl_Position = u_ViewProj * m_World * a_Position;
 }

--- a/data/shaders/sprite_vs.glsl
+++ b/data/shaders/sprite_vs.glsl
@@ -7,11 +7,10 @@ out vec2 v_TexCoord;
 in vec4 i_World0;
 in vec4 i_World1;
 in vec4 i_World2;
-in vec4 i_World3;
 in vec4 i_UvRange;
 
 void main() {
-    mat4 m_World = mat4(i_World0, i_World1, i_World2, i_World3);
+    mat4 m_World = transpose(mat4(i_World0, i_World1, i_World2, vec4(0.0, 0.0, 0.0, 1.0)));
     v_TexCoord = mix(i_UvRange.xy, i_UvRange.zw, a_TexCoord);
     gl_Position = u_ViewProj * m_World * a_Position;
 }

--- a/examples/anim.rs
+++ b/examples/anim.rs
@@ -38,12 +38,10 @@ const BIT_VERTEX_COLOR: u16 = 0x80;
 fn make_vertices(slice: &[i16]) -> Vec<mint::Point3<f32>> {
     slice
         .chunks(3)
-        .map(|v| {
-            mint::Point3 {
-                x: v[0] as f32 * SCALE,
-                y: v[1] as f32 * SCALE,
-                z: v[2] as f32 * SCALE,
-            }
+        .map(|v| mint::Point3 {
+            x: v[0] as f32 * SCALE,
+            y: v[1] as f32 * SCALE,
+            z: v[2] as f32 * SCALE,
         })
         .collect()
 }

--- a/examples/group.rs
+++ b/examples/group.rs
@@ -132,7 +132,7 @@ fn main() {
     let mut fps_counter = win.factory.ui_text(&font, "FPS: 00");
 
     let timer = win.input.time();
-    println!("{}", cubes.len());
+    println!("Total number of cubes: {}", cubes.len());
     while win.update() && !win.input.hit(three::KEY_ESCAPE) {
         let time = timer.get(&win.input);
         let delta_time = win.input.delta_time();

--- a/examples/group.rs
+++ b/examples/group.rs
@@ -132,9 +132,14 @@ fn main() {
     let mut cubes = create_cubes(&mut win.factory, &materials, &levels);
     cubes[0].group.set_parent(&win.scene);
 
+    let font = win.factory.load_font(format!("{}/data/fonts/DejaVuSans.ttf", env!("CARGO_MANIFEST_DIR")));
+    let mut fps_counter = win.factory.ui_text(&font, "FPS: 00");
+
     let timer = win.input.time();
     while win.update() && !win.input.hit(three::KEY_ESCAPE) {
         let time = timer.get(&win.input);
+        let delta_time = win.input.delta_time();
+        fps_counter.set_text(format!("FPS: {}", 1.0 / delta_time));
         for cube in cubes.iter_mut() {
             let level = &levels[cube.level_id];
             let angle = Rad(time * level.speed);

--- a/examples/group.rs
+++ b/examples/group.rs
@@ -104,14 +104,7 @@ fn create_cubes(
 
 const COLORS: [three::Color; 6] = [0xffff80, 0x8080ff, 0x80ff80, 0xff8080, 0x80ffff, 0xff80ff];
 
-const SPEEDS: [f32; 5] = [
-    0.7,
-    -1.0,
-    1.3,
-    -1.6,
-    1.9,
-    //-2.2, //TODO when performance allows
-];
+const SPEEDS: [f32; 6] = [0.7, -1.0, 1.3, -1.6, 1.9, -2.2];
 
 fn main() {
     let mut win = three::Window::new("Three-rs group example");
@@ -132,10 +125,14 @@ fn main() {
     let mut cubes = create_cubes(&mut win.factory, &materials, &levels);
     cubes[0].group.set_parent(&win.scene);
 
-    let font = win.factory.load_font(format!("{}/data/fonts/DejaVuSans.ttf", env!("CARGO_MANIFEST_DIR")));
+    let font = win.factory.load_font(format!(
+        "{}/data/fonts/DejaVuSans.ttf",
+        env!("CARGO_MANIFEST_DIR")
+    ));
     let mut fps_counter = win.factory.ui_text(&font, "FPS: 00");
 
     let timer = win.input.time();
+    println!("{}", cubes.len());
     while win.update() && !win.input.hit(three::KEY_ESCAPE) {
         let time = timer.get(&win.input);
         let delta_time = win.input.delta_time();

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,7 +1,9 @@
 reorder_imports = true
-reorder_import_names = true
+reorder_extern_crates = true
+reorder_extern_crates_in_group = true
+reorder_imported_names = true
 reorder_imports_in_group = true
-error_on_line_overflow_comments = false
+error_on_line_overflow = false
 max_width = 15000
 spaces_around_ranges = true
 fn_args_density = "Vertical"

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -286,7 +286,6 @@ struct ActionData {
 
     /// Time scaling factor.
     pub local_time_scale: f32,
-
     // Unimplemented properties
     // ------------------------
     // * weight

--- a/src/factory/load_gltf.rs
+++ b/src/factory/load_gltf.rs
@@ -130,9 +130,13 @@ impl super::Factory {
                 base_color_alpha,
                 metallic_factor: pbr.metallic_factor(),
                 roughness_factor: pbr.roughness_factor(),
-                occlusion_strength: mat.occlusion_texture().map_or(1.0, |t| t.strength()),
+                occlusion_strength: mat.occlusion_texture().map_or(1.0, |t| {
+                    t.strength()
+                }),
                 emissive_factor: color::from_linear_rgb(mat.emissive_factor()),
-                normal_scale: mat.normal_texture().map_or(1.0, |t| t.scale()),
+                normal_scale: mat.normal_texture().map_or(1.0, |t| {
+                    t.scale()
+                }),
                 base_color_map,
                 normal_map,
                 emissive_map,

--- a/src/factory/mod.rs
+++ b/src/factory/mod.rs
@@ -246,7 +246,7 @@ impl Factory {
     ) -> Mesh {
         let vertices = Self::mesh_vertices(&geometry.base_shape);
         let instances = self.create_instance_buffer();
-        let (vbuf, mut slice) = if geometry.faces.is_empty() {
+        let (vertices, mut slice) = if geometry.faces.is_empty() {
             self.backend.create_vertex_buffer_with_slice(&vertices, ())
         } else {
             let faces: &[u32] = gfx::memory::cast_slice(&geometry.faces);
@@ -254,13 +254,12 @@ impl Factory {
                 .create_vertex_buffer_with_slice(&vertices, faces)
         };
         slice.instances = Some((1, 0));
-        let material = material.into();
         Mesh {
             object: self.hub.lock().unwrap().spawn_visual(
-                material,
+                material.into(),
                 GpuData {
                     slice,
-                    vertices: vbuf.clone(),
+                    vertices,
                     instances,
                     pending: None,
                     instance_cache_key: None,
@@ -302,13 +301,12 @@ impl Factory {
             (data.len(), dest_buf, upload_buf)
         };
         let instances = self.create_instance_buffer();
-        let material = material.into();
         DynamicMesh {
             object: self.hub.lock().unwrap().spawn_visual(
-                material,
+                material.into(),
                 GpuData {
                     slice,
-                    vertices: vertices.clone(),
+                    vertices,
                     instances,
                     pending: None,
                     instance_cache_key: None,
@@ -870,7 +868,7 @@ impl Factory {
                 };
                 info!("\t{:?}", material);
 
-                let (vbuf, mut slice) = self.backend
+                let (vertices, mut slice) = self.backend
                     .create_vertex_buffer_with_slice(&vertices, &indices[..]);
                 slice.instances = Some((1, 0));
                 let instances = self.backend
@@ -886,7 +884,7 @@ impl Factory {
                         material,
                         GpuData {
                             slice,
-                            vertices: vbuf.clone(),
+                            vertices,
                             instances,
                             pending: None,
                             instance_cache_key: None,

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -190,8 +190,8 @@ impl Hub {
                     *mat = material;
                 },
                 Operation::SetTexelRange(base, size) => if let SubNode::Visual(ref mut material, _) = node.sub_node {
-                    match material.mat_type {
-                        material::MaterialType::Sprite(ref mut params) => params.map.set_texel_range(base, size),
+                    match *material {
+                        material::Material::Sprite(ref mut params) => params.map.set_texel_range(base, size),
                         _ => panic!("Unsupported material for texel range request"),
                     }
                 },

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -190,8 +190,8 @@ impl Hub {
                     *mat = material;
                 },
                 Operation::SetTexelRange(base, size) => if let SubNode::Visual(ref mut material, _) = node.sub_node {
-                    match *material {
-                        material::Material::Sprite(ref mut params) => params.map.set_texel_range(base, size),
+                    match material.mat_type {
+                        material::MaterialType::Sprite(ref mut params) => params.map.set_texel_range(base, size),
                         _ => panic!("Unsupported material for texel range request"),
                     }
                 },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,7 +255,10 @@
 
 #[macro_use]
 extern crate bitflags;
+extern crate byteorder;
 extern crate cgmath;
+#[macro_use]
+extern crate derivative;
 extern crate froggy;
 extern crate genmesh;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,7 +255,6 @@
 
 #[macro_use]
 extern crate bitflags;
-extern crate byteorder;
 extern crate cgmath;
 #[macro_use]
 extern crate derivative;

--- a/src/material.rs
+++ b/src/material.rs
@@ -120,13 +120,13 @@ pub struct Pbr {
     /// Base color alpha factor applied in the absense of `base_color_map`.
     ///
     /// Default: `1.0` (opaque).
-    #[derivative(Hash(hash_with="util::hash_f32"))]
+    #[derivative(Hash(hash_with = "util::hash_f32"))]
     pub base_color_alpha: f32,
 
     /// Metallic factor in the range [0.0, 1.0].
     ///
     /// Default: `1.0`.
-    #[derivative(Hash(hash_with="util::hash_f32"))]
+    #[derivative(Hash(hash_with = "util::hash_f32"))]
     pub metallic_factor: f32,
 
     /// Roughness factor in the range [0.0, 1.0].
@@ -135,14 +135,14 @@ pub struct Pbr {
     /// * A value of 0.0 means the material is completely smooth.
     ///
     /// Default: `1.0`.
-    #[derivative(Hash(hash_with="util::hash_f32"))]
+    #[derivative(Hash(hash_with = "util::hash_f32"))]
     pub roughness_factor: f32,
 
     /// Scalar multiplier in the range [0.0, 1.0] that controls the amount of
     /// occlusion applied in the presense of `occlusion_map`.
     ///
     /// Default: `1.0`.
-    #[derivative(Hash(hash_with="util::hash_f32"))]
+    #[derivative(Hash(hash_with = "util::hash_f32"))]
     pub occlusion_strength: f32,
 
     /// Solid emissive color applied in the absense of `emissive_map`.
@@ -155,7 +155,7 @@ pub struct Pbr {
     /// This value is ignored in the absense of `normal_map`.
     ///
     /// Default: `1.0`.
-    #[derivative(Hash(hash_with="util::hash_f32"))]
+    #[derivative(Hash(hash_with = "util::hash_f32"))]
     pub normal_scale: f32,
 
     /// Base color texture.
@@ -219,7 +219,7 @@ pub struct Phong {
     /// Higher values result in sharper highlights to produce a glossy effect.
     ///
     /// Default: `30.0`.
-    #[derivative(Hash(hash_with="util::hash_f32"))]
+    #[derivative(Hash(hash_with = "util::hash_f32"))]
     pub glossiness: f32,
 }
 

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -107,11 +107,11 @@ impl Hash for DynamicMesh {
 
 impl Mesh {
     /// Set mesh material.
-    pub fn set_material(
+    pub fn set_material<M: Into<Material>>(
         &mut self,
-        material: Material,
+        material: M,
     ) {
-        let msg = Operation::SetMaterial(material);
+        let msg = Operation::SetMaterial(material.into());
         let _ = self.object.tx.send((self.object.node.downgrade(), msg));
     }
 }
@@ -123,11 +123,11 @@ impl DynamicMesh {
     }
 
     /// Set mesh material.
-    pub fn set_material(
+    pub fn set_material<M: Into<Material>>(
         &mut self,
-        material: Material,
+        material: M,
     ) {
-        let msg = Operation::SetMaterial(material);
+        let msg = Operation::SetMaterial(material.into());
         let _ = self.object.tx.send((self.object.node.downgrade(), msg));
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -4,6 +4,7 @@ use cgmath::{Matrix4, SquareMatrix, Transform as Transform_, Vector3};
 use color;
 use froggy;
 use gfx;
+use gfx::handle as h;
 use gfx::memory::Typed;
 use gfx::traits::{Device, Factory as Factory_, FactoryExt};
 #[cfg(feature = "opengl")]
@@ -15,21 +16,23 @@ use glutin;
 use mint;
 
 pub mod source;
+mod pso_data;
 
-use std::{io, mem, str};
+use std::{io, str};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
 pub use self::back::CommandBuffer as BackendCommandBuffer;
 pub use self::back::Factory as BackendFactory;
 pub use self::back::Resources as BackendResources;
+use self::pso_data::PsoData;
 pub use self::source::Source;
 
 use camera::Camera;
 use factory::Factory;
 use hub::{SubLight, SubNode};
 use light::{ShadowMap, ShadowProjection};
-use material::Material;
+use material::MaterialType;
 use scene::{Background, Scene};
 use text::Font;
 use texture::Texture;
@@ -44,6 +47,9 @@ pub type ShadowFormat = gfx::format::Depth32F;
 pub type BasicPipelineState = gfx::PipelineState<back::Resources, basic_pipe::Meta>;
 
 const MAX_LIGHTS: usize = 4;
+
+// TODO: Allow to adjust
+const INSTANCE_COUNT: usize = 64;
 
 const STENCIL_SIDE: gfx::state::StencilSide = gfx::state::StencilSide {
     fun: gfx::state::Comparison::Always,
@@ -94,11 +100,14 @@ gfx_defines! {
         tangent: [gfx::format::I8Norm; 4] = "a_Tangent",
     }
 
-    constant Locals {
-        mx_world: [[f32; 4]; 4] = "u_World",
-        color: [f32; 4] = "u_Color",
-        mat_params: [f32; 4] = "u_MatParams",
-        uv_range: [f32; 4] = "u_UvRange",
+    vertex Instance {
+        world0: [f32; 4] = "i_World0",
+        world1: [f32; 4] = "i_World1",
+        world2: [f32; 4] = "i_World2",
+        world3: [f32; 4] = "i_World3",
+        color: [f32; 4] = "i_Color",
+        mat_params: [f32; 4] = "i_MatParams",
+        uv_range: [f32; 4] = "i_UvRange",
     }
 
     constant LightParam {
@@ -121,7 +130,7 @@ gfx_defines! {
 
     pipeline basic_pipe {
         vbuf: gfx::VertexBuffer<Vertex> = (),
-        cb_locals: gfx::ConstantBuffer<Locals> = "b_Locals",
+        inst_buf: gfx::InstanceBuffer<Instance> = (),
         cb_lights: gfx::ConstantBuffer<LightParam> = "b_Lights",
         cb_globals: gfx::ConstantBuffer<Globals> = "b_Globals",
         tex_map: gfx::TextureSampler<[f32; 4]> = "t_Map",
@@ -137,7 +146,7 @@ gfx_defines! {
 
     pipeline shadow_pipe {
         vbuf: gfx::VertexBuffer<Vertex> = (),
-        cb_locals: gfx::ConstantBuffer<Locals> = "b_Locals",
+        inst_buf: gfx::InstanceBuffer<Instance> = (),
         cb_globals: gfx::ConstantBuffer<Globals> = "b_Globals",
         target: gfx::DepthTarget<ShadowFormat> =
             gfx::preset::depth::LESS_EQUAL_WRITE,
@@ -172,8 +181,8 @@ gfx_defines! {
 
     pipeline pbr_pipe {
         vbuf: gfx::VertexBuffer<Vertex> = (),
+        inst_buf: gfx::InstanceBuffer<Instance> = (),
 
-        locals: gfx::ConstantBuffer<Locals> = "b_Locals",
         globals: gfx::ConstantBuffer<Globals> = "b_Globals",
         params: gfx::ConstantBuffer<PbrParams> = "b_PbrParams",
         lights: gfx::ConstantBuffer<LightParam> = "b_Lights",
@@ -193,19 +202,71 @@ gfx_defines! {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct InstanceCacheKey {
+    pub(crate) material_id: usize,
+    pub(crate) geometry_id: h::Buffer<back::Resources, Vertex>,
+}
+
+impl Instance {
+    #[inline]
+    fn basic(
+        mx_world: [[f32; 4]; 4],
+        color: u32,
+        uv_range: [f32; 4],
+        param: f32,
+    ) -> Instance {
+        Instance {
+            world0: mx_world[0],
+            world1: mx_world[1],
+            world2: mx_world[2],
+            world3: mx_world[3],
+            color: {
+                let rgb = color::to_linear_rgb(color);
+                [rgb[0], rgb[1], rgb[2], 0.0]
+            },
+            mat_params: [param, 0.0, 0.0, 0.0],
+            uv_range,
+        }
+    }
+
+    #[inline]
+    fn pbr(mx_world: [[f32; 4]; 4]) -> Instance {
+        Instance {
+            world0: mx_world[0],
+            world1: mx_world[1],
+            world2: mx_world[2],
+            world3: mx_world[3],
+            color: [0.0; 4],
+            mat_params: [0.0; 4],
+            uv_range: [0.0; 4],
+        }
+    }
+}
+
 //TODO: private fields?
 #[derive(Clone, Debug)]
 pub(crate) struct GpuData {
     pub slice: gfx::Slice<back::Resources>,
-    pub vertices: gfx::handle::Buffer<back::Resources, Vertex>,
-    pub constants: gfx::handle::Buffer<back::Resources, Locals>,
+    pub vertices: h::Buffer<back::Resources, Vertex>,
+    pub instances: h::Buffer<back::Resources, Instance>,
     pub pending: Option<DynamicData>,
+    pub use_instancing: bool,
+    pub instance_cache_key: InstanceCacheKey,
+}
+
+#[derive(Clone, Debug)]
+struct InstanceData {
+    pub slice: gfx::Slice<back::Resources>,
+    pub vertices: h::Buffer<back::Resources, Vertex>,
+    pub pso_data: PsoData,
+    pub mat_type: MaterialType,
 }
 
 #[derive(Clone, Debug)]
 pub(crate) struct DynamicData {
     pub num_vertices: usize,
-    pub buffer: gfx::handle::Buffer<back::Resources, Vertex>,
+    pub buffer: h::Buffer<back::Resources, Vertex>,
 }
 
 /// Shadow type is used to specify shadow's rendering algorithm.
@@ -218,18 +279,8 @@ pub enum ShadowType {
     Pcf,
 }
 
-bitflags! {
-    struct PbrFlags: i32 {
-        const BASE_COLOR_MAP         = 1 << 0;
-        const NORMAL_MAP             = 1 << 1;
-        const METALLIC_ROUGHNESS_MAP = 1 << 2;
-        const EMISSIVE_MAP           = 1 << 3;
-        const OCCLUSION_MAP          = 1 << 4;
-    }
-}
-
 struct DebugQuad {
-    resource: gfx::handle::RawShaderResourceView<back::Resources>,
+    resource: h::RawShaderResourceView<back::Resources>,
     pos: [i32; 2],
     size: [i32; 2],
 }
@@ -378,6 +429,21 @@ impl PipelineStates {
             skybox: pso_skybox,
         })
     }
+
+    pub(crate) fn pso_by_material(
+        &self,
+        material: &MaterialType,
+    ) -> &BasicPipelineState {
+        match *material {
+            MaterialType::Basic(_) => &self.mesh_basic_fill,
+            MaterialType::Line(_) => &self.line_basic,
+            MaterialType::Wireframe(_) => &self.mesh_basic_wireframe,
+            MaterialType::Lambert(_) => &self.mesh_gouraud,
+            MaterialType::Phong(_) => &self.mesh_phong,
+            MaterialType::Sprite(_) => &self.sprite,
+            _ => unreachable!(),
+        }
+    }
 }
 
 /// Handle for additional viewport to render some relevant debug information.
@@ -391,18 +457,21 @@ pub struct DebugQuadHandle(froggy::Pointer<DebugQuad>);
 pub struct Renderer {
     device: back::Device,
     encoder: gfx::Encoder<back::Resources, back::CommandBuffer>,
-    const_buf: gfx::handle::Buffer<back::Resources, Globals>,
-    quad_buf: gfx::handle::Buffer<back::Resources, QuadParams>,
-    light_buf: gfx::handle::Buffer<back::Resources, LightParam>,
-    pbr_buf: gfx::handle::Buffer<back::Resources, PbrParams>,
-    out_color: gfx::handle::RenderTargetView<back::Resources, ColorFormat>,
-    out_depth: gfx::handle::DepthStencilView<back::Resources, DepthFormat>,
+    factory: back::Factory,
+    const_buf: h::Buffer<back::Resources, Globals>,
+    quad_buf: h::Buffer<back::Resources, QuadParams>,
+    inst_buf: h::Buffer<back::Resources, Instance>,
+    light_buf: h::Buffer<back::Resources, LightParam>,
+    pbr_buf: h::Buffer<back::Resources, PbrParams>,
+    out_color: h::RenderTargetView<back::Resources, ColorFormat>,
+    out_depth: h::DepthStencilView<back::Resources, DepthFormat>,
     pso: PipelineStates,
     map_default: Texture<[f32; 4]>,
     shadow_default: Texture<f32>,
     debug_quads: froggy::Storage<DebugQuad>,
     size: (u32, u32),
     font_cache: HashMap<PathBuf, Font>,
+    instance_cache: HashMap<InstanceCacheKey, (InstanceData, Vec<Instance>)>,
     /// `ShadowType` of this `Renderer`.
     pub shadow: ShadowType,
 }
@@ -434,19 +503,30 @@ impl Renderer {
         let quad_buf = gl_factory.create_constant_buffer(1);
         let light_buf = gl_factory.create_constant_buffer(MAX_LIGHTS);
         let pbr_buf = gl_factory.create_constant_buffer(1);
+        let inst_buf = gl_factory
+            .create_buffer(
+                1,
+                gfx::buffer::Role::Vertex,
+                gfx::memory::Usage::Dynamic,
+                gfx::TRANSFER_DST,
+            )
+            .unwrap();
         let pso = PipelineStates::init(source, &mut gl_factory).unwrap();
         let renderer = Renderer {
             device,
+            factory: gl_factory.clone(),
             encoder,
             const_buf,
             quad_buf,
             light_buf,
+            inst_buf,
             pbr_buf,
             out_color,
             out_depth,
             pso,
             map_default: Texture::new(srv_white, sampler, [1, 1]),
             shadow_default: Texture::new(srv_shadow, sampler_shadow, [1, 1]),
+            instance_cache: HashMap::new(),
             shadow: ShadowType::Basic,
             debug_quads: froggy::Storage::new(),
             font_cache: HashMap::new(),
@@ -455,6 +535,8 @@ impl Renderer {
         let factory = Factory::new(gl_factory);
         (renderer, window, factory)
     }
+
+
 
     /// Reloads the shaders.
     pub fn reload(
@@ -534,8 +616,8 @@ impl Renderer {
 
         // gather lights
         struct ShadowRequest {
-            target: gfx::handle::DepthStencilView<back::Resources, ShadowFormat>,
-            resource: gfx::handle::ShaderResourceView<back::Resources, f32>,
+            target: h::DepthStencilView<back::Resources, ShadowFormat>,
+            resource: h::ShaderResourceView<back::Resources, f32>,
             mx_view: Matrix4<f32>,
             mx_proj: Matrix4<f32>,
         }
@@ -631,19 +713,14 @@ impl Renderer {
                     SubNode::Visual(_, ref data) => data,
                     _ => continue,
                 };
-                self.encoder.update_constant_buffer(
-                    &gpu_data.constants,
-                    &Locals {
-                        mx_world: Matrix4::from(node.world_transform).into(),
-                        color: [0.0; 4],
-                        mat_params: [0.0; 4],
-                        uv_range: [0.0; 4],
-                    },
-                );
+                let mx_world: [[f32; 4]; 4] = Matrix4::from(node.world_transform).into();
+                self.encoder
+                    .update_buffer(&gpu_data.instances, &[Instance::pbr(mx_world)], 0)
+                    .unwrap();
                 //TODO: avoid excessive cloning
                 let data = shadow_pipe::Data {
                     vbuf: gpu_data.vertices.clone(),
-                    cb_locals: gpu_data.constants.clone(),
+                    inst_buf: gpu_data.instances.clone(),
                     cb_globals: self.const_buf.clone(),
                     target: request.target.clone(),
                 };
@@ -697,6 +774,12 @@ impl Renderer {
             Some(ref request) => request.resource.clone(),
             None => shadow_default.clone(),
         };
+
+        // clear instance cache
+        for instances in self.instance_cache.values_mut() {
+            instances.1.clear();
+        }
+
         for node in hub.nodes.iter() {
             if !node.visible || node.scene_id != scene_id {
                 continue;
@@ -706,146 +789,97 @@ impl Renderer {
                 _ => continue,
             };
 
-            //TODO: batch per PSO
-            match *material {
-                Material::Pbr(ref params) => {
-                    self.encoder.update_constant_buffer(
-                        &gpu_data.constants,
-                        &Locals {
-                            mx_world: Matrix4::from(node.world_transform).into(),
-                            ..unsafe { mem::zeroed() }
-                        },
-                    );
-                    let mut pbr_flags = PbrFlags::empty();
-                    if params.base_color_map.is_some() {
-                        pbr_flags.insert(BASE_COLOR_MAP);
-                    }
-                    if params.normal_map.is_some() {
-                        pbr_flags.insert(NORMAL_MAP);
-                    }
-                    if params.metallic_roughness_map.is_some() {
-                        pbr_flags.insert(METALLIC_ROUGHNESS_MAP);
-                    }
-                    if params.emissive_map.is_some() {
-                        pbr_flags.insert(EMISSIVE_MAP);
-                    }
-                    if params.occlusion_map.is_some() {
-                        pbr_flags.insert(OCCLUSION_MAP);
-                    }
-                    let bcf = color::to_linear_rgb(params.base_color_factor);
-                    let emf = color::to_linear_rgb(params.emissive_factor);
-                    self.encoder.update_constant_buffer(
-                        &self.pbr_buf,
-                        &PbrParams {
-                            base_color_factor: [bcf[0], bcf[1], bcf[2], params.base_color_alpha],
-                            camera: [0.0, 0.0, 1.0],
-                            emissive_factor: [emf[0], emf[1], emf[2]],
-                            metallic_roughness: [params.metallic_factor, params.roughness_factor],
-                            normal_scale: params.normal_scale,
-                            occlusion_strength: params.occlusion_strength,
-                            pbr_flags: pbr_flags.bits(),
-                            _padding0: unsafe { mem::uninitialized() },
-                            _padding1: unsafe { mem::uninitialized() },
-                        },
-                    );
-                    let data = pbr_pipe::Data {
-                        vbuf: gpu_data.vertices.clone(),
-                        locals: gpu_data.constants.clone(),
-                        globals: self.const_buf.clone(),
-                        lights: self.light_buf.clone(),
-                        params: self.pbr_buf.clone(),
-                        base_color_map: {
-                            params
-                                .base_color_map
-                                .as_ref()
-                                .unwrap_or(&self.map_default)
-                                .to_param()
-                        },
-                        normal_map: {
-                            params
-                                .normal_map
-                                .as_ref()
-                                .unwrap_or(&self.map_default)
-                                .to_param()
-                        },
-                        emissive_map: {
-                            params
-                                .emissive_map
-                                .as_ref()
-                                .unwrap_or(&self.map_default)
-                                .to_param()
-                        },
-                        metallic_roughness_map: {
-                            params
-                                .metallic_roughness_map
-                                .as_ref()
-                                .unwrap_or(&self.map_default)
-                                .to_param()
-                        },
-                        occlusion_map: {
-                            params
-                                .occlusion_map
-                                .as_ref()
-                                .unwrap_or(&self.map_default)
-                                .to_param()
-                        },
-                        color_target: self.out_color.clone(),
-                        depth_target: self.out_depth.clone(),
-                    };
-                    self.encoder.draw(&gpu_data.slice, &self.pso.pbr, &data);
-                }
-                ref other => {
-                    let (pso, color, param0, map) = match *other {
-                        Material::Pbr(_) => unreachable!(),
-                        Material::Basic(ref params) => (
-                            &self.pso.mesh_basic_fill,
-                            params.color,
-                            0.0,
-                            params.map.as_ref(),
-                        ),
-                        Material::CustomBasic(ref params) => (&params.pipeline, params.color, 0.0, params.map.as_ref()),
-                        Material::Lambert(ref params) => (
-                            &self.pso.mesh_gouraud,
-                            params.color,
-                            if params.flat { 0.0 } else { 1.0 },
-                            None,
-                        ),
-                        Material::Line(ref params) => (&self.pso.line_basic, params.color, 0.0, None),
-                        Material::Phong(ref params) => (&self.pso.mesh_phong, params.color, params.glossiness, None),
-                        Material::Sprite(ref params) => (&self.pso.sprite, !0, 0.0, Some(&params.map)),
-                        Material::Wireframe(ref params) => (&self.pso.mesh_basic_wireframe, params.color, 0.0, None),
-                    };
+            let mx_world: [[f32; 4]; 4] = Matrix4::from(node.world_transform).into();
+            let pso_data = material.mat_type.to_pso_data();
+
+            if gpu_data.use_instancing {
+                let uv_range = [0.0; 4];
+                let key = gpu_data.instance_cache_key.clone();
+                let color = match pso_data {
+                    PsoData::Basic { color, .. } => color,
+                    PsoData::Pbr { .. } => !0,
+                };
+                let mat_param = match pso_data {
+                    PsoData::Basic { param0, .. } => param0,
+                    PsoData::Pbr { .. } => 0.0,
+                };
+                let vec = self.instance_cache.entry(key).or_insert((
+                    InstanceData {
+                        slice: gpu_data.slice.clone(),
+                        vertices: gpu_data.vertices.clone(),
+                        pso_data: pso_data.clone(),
+                        mat_type: material.mat_type.clone(),
+                    },
+                    Vec::new(),
+                ));
+                vec.1
+                    .push(Instance::basic(mx_world, color, uv_range, mat_param));
+                continue;
+            }
+            let instance = match pso_data {
+                PsoData::Basic { color, map, param0 } => {
                     let uv_range = match map {
                         Some(ref map) => map.uv_range(),
                         None => [0.0; 4],
                     };
-                    self.encoder.update_constant_buffer(
-                        &gpu_data.constants,
-                        &Locals {
-                            mx_world: Matrix4::from(node.world_transform).into(),
-                            color: {
-                                let rgb = color::to_linear_rgb(color);
-                                [rgb[0], rgb[1], rgb[2], 0.0]
-                            },
-                            mat_params: [param0, 0.0, 0.0, 0.0],
-                            uv_range,
-                        },
-                    );
-                    //TODO: avoid excessive cloning
-                    let data = basic_pipe::Data {
-                        vbuf: gpu_data.vertices.clone(),
-                        cb_locals: gpu_data.constants.clone(),
-                        cb_lights: self.light_buf.clone(),
-                        cb_globals: self.const_buf.clone(),
-                        tex_map: map.unwrap_or(&self.map_default).to_param(),
-                        shadow_map0: (shadow0.clone(), shadow_sampler.clone()),
-                        shadow_map1: (shadow1.clone(), shadow_sampler.clone()),
-                        out_color: self.out_color.clone(),
-                        out_depth: (self.out_depth.clone(), (0, 0)),
-                    };
-                    self.encoder.draw(&gpu_data.slice, pso, &data);
+                    Instance::basic(mx_world, color, uv_range, param0)
                 }
+                PsoData::Pbr { .. } => Instance::pbr(mx_world),
             };
+
+            Self::render_mesh(
+                &mut self.encoder,
+                self.const_buf.clone(),
+                gpu_data.instances.clone(),
+                self.light_buf.clone(),
+                self.pbr_buf.clone(),
+                self.out_color.clone(),
+                self.out_depth.clone(),
+                &self.pso,
+                &self.map_default,
+                &[instance],
+                gpu_data.vertices.clone(),
+                gpu_data.slice.clone(),
+                &material.mat_type,
+                &shadow_sampler,
+                &shadow0,
+                &shadow1,
+            );
+        }
+
+        // render instanced meshes
+        for &(ref mesh_data, ref all_instances) in self.instance_cache.values() {
+            if all_instances.len() > self.inst_buf.len() {
+                self.inst_buf = self.factory
+                    .create_buffer(
+                        all_instances.len(),
+                        gfx::buffer::Role::Vertex,
+                        gfx::memory::Usage::Dynamic,
+                        gfx::TRANSFER_DST,
+                    )
+                    // TODO: Better error handling
+                    .unwrap();
+            }
+            for instances in all_instances.chunks(INSTANCE_COUNT) {
+                Self::render_mesh(
+                    &mut self.encoder,
+                    self.const_buf.clone(),
+                    self.inst_buf.clone(),
+                    self.light_buf.clone(),
+                    self.pbr_buf.clone(),
+                    self.out_color.clone(),
+                    self.out_depth.clone(),
+                    &self.pso,
+                    &self.map_default,
+                    instances,
+                    mesh_data.vertices.clone(),
+                    mesh_data.slice.clone(),
+                    &mesh_data.mat_type,
+                    &shadow_sampler,
+                    &shadow0,
+                    &shadow1,
+                );
+            }
         }
 
         let quad_slice = gfx::Slice {
@@ -952,6 +986,76 @@ impl Renderer {
 
         self.encoder.flush(&mut self.device);
     }
+
+
+    #[inline]
+    fn render_mesh(
+        encoder: &mut gfx::Encoder<back::Resources, back::CommandBuffer>,
+        const_buf: h::Buffer<back::Resources, Globals>,
+        inst_buf: h::Buffer<back::Resources, Instance>,
+        light_buf: h::Buffer<back::Resources, LightParam>,
+        pbr_buf: h::Buffer<back::Resources, PbrParams>,
+        out_color: h::RenderTargetView<back::Resources, ColorFormat>,
+        out_depth: h::DepthStencilView<back::Resources, DepthFormat>,
+        pso: &PipelineStates,
+        map_default: &Texture<[f32; 4]>,
+        instances: &[Instance],
+        vertex_buf: h::Buffer<back::Resources, Vertex>,
+        slice: gfx::Slice<back::Resources>,
+        mat_type: &MaterialType,
+        shadow_sampler: &h::Sampler<back::Resources>,
+        shadow0: &h::ShaderResourceView<back::Resources, f32>,
+        shadow1: &h::ShaderResourceView<back::Resources, f32>,
+    ) {
+        encoder.update_buffer(&inst_buf, instances, 0).unwrap();
+
+        let slice = if instances.len() > 1 {
+            let mut slice = slice;
+            slice.instances = Some((instances.len() as u32, 0));
+            slice
+        } else {
+            slice
+        };
+
+        //TODO: batch per PSO
+        match mat_type.to_pso_data() {
+            PsoData::Pbr { maps, params } => {
+                encoder.update_constant_buffer(&pbr_buf, &params);
+                let map_params = maps.to_params(map_default);
+                let data = pbr_pipe::Data {
+                    vbuf: vertex_buf,
+                    inst_buf: inst_buf,
+                    globals: const_buf.clone(),
+                    lights: light_buf.clone(),
+                    params: pbr_buf.clone(),
+                    base_color_map: map_params.base_color,
+                    normal_map: map_params.normal,
+                    emissive_map: map_params.emissive,
+                    metallic_roughness_map: map_params.metallic_roughness,
+                    occlusion_map: map_params.occlusion,
+                    color_target: out_color.clone(),
+                    depth_target: out_depth.clone(),
+                };
+                encoder.draw(&slice, &pso.pbr, &data);
+            }
+            PsoData::Basic { map, .. } => {
+                //TODO: avoid excessive cloning
+                let data = basic_pipe::Data {
+                    vbuf: vertex_buf,
+                    inst_buf: inst_buf,
+                    cb_lights: light_buf.clone(),
+                    cb_globals: const_buf.clone(),
+                    tex_map: map.unwrap_or(map_default.clone()).to_param(),
+                    shadow_map0: (shadow0.clone(), shadow_sampler.clone()),
+                    shadow_map1: (shadow1.clone(), shadow_sampler.clone()),
+                    out_color: out_color.clone(),
+                    out_depth: (out_depth.clone(), (0, 0)),
+                };
+                encoder.draw(&slice, pso.pso_by_material(&mat_type), &data);
+            }
+        }
+    }
+
 
     /// Draw [`ShadowMap`](struct.ShadowMap.html) for debug purposes.
     pub fn debug_shadow_quad(

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -27,6 +27,7 @@ pub use self::back::Factory as BackendFactory;
 pub use self::back::Resources as BackendResources;
 pub use self::source::Source;
 
+use self::pso_data::PsoData;
 use camera::Camera;
 use factory::Factory;
 use hub::{SubLight, SubNode};
@@ -35,7 +36,6 @@ use material::Material;
 use scene::{Background, Scene};
 use text::Font;
 use texture::Texture;
-use self::pso_data::PsoData;
 
 /// The format of the back buffer color requested from the windowing system.
 pub type ColorFormat = gfx::format::Rgba8;
@@ -207,15 +207,15 @@ pub(crate) struct InstanceCacheKey {
 impl Instance {
     #[inline]
     fn basic(
-        mx_world_transposed: mint::RowMatrix4<f32>,
+        mx_world: mint::RowMatrix4<f32>,
         color: u32,
         uv_range: [f32; 4],
         param: f32,
     ) -> Self {
         Instance {
-            world0: mx_world_transposed.x.into(),
-            world1: mx_world_transposed.y.into(),
-            world2: mx_world_transposed.z.into(),
+            world0: mx_world.x.into(),
+            world1: mx_world.y.into(),
+            world2: mx_world.z.into(),
             color: {
                 // TODO: add alpha parameter for `to_linear_rgb`
                 let rgb = color::to_linear_rgb(color);
@@ -227,11 +227,11 @@ impl Instance {
     }
 
     #[inline]
-    fn pbr(mx_world_transposed: mint::RowMatrix4<f32>) -> Self {
+    fn pbr(mx_world: mint::RowMatrix4<f32>) -> Self {
         Instance {
-            world0: mx_world_transposed.x.into(),
-            world1: mx_world_transposed.y.into(),
-            world2: mx_world_transposed.z.into(),
+            world0: mx_world.x.into(),
+            world1: mx_world.y.into(),
+            world2: mx_world.z.into(),
             color: [0.0; 4],
             mat_params: [0.0; 4],
             uv_range: [0.0; 4],
@@ -529,8 +529,6 @@ impl Renderer {
         let factory = Factory::new(gl_factory);
         (renderer, window, factory)
     }
-
-
 
     /// Reloads the shaders.
     pub fn reload(
@@ -978,7 +976,6 @@ impl Renderer {
         self.encoder.flush(&mut self.device);
     }
 
-
     #[inline]
     fn render_mesh(
         encoder: &mut gfx::Encoder<back::Resources, back::CommandBuffer>,
@@ -1047,7 +1044,6 @@ impl Renderer {
             }
         }
     }
-
 
     /// Draw [`ShadowMap`](struct.ShadowMap.html) for debug purposes.
     pub fn debug_shadow_quad(

--- a/src/render/pso_data.rs
+++ b/src/render/pso_data.rs
@@ -1,6 +1,6 @@
 use color;
 use gfx::handle as h;
-use material::MaterialType;
+use material::Material;
 use render::{BackendResources, PbrParams};
 use std::mem;
 use texture::Texture;
@@ -39,7 +39,7 @@ pub(crate) struct PbrMapParams {
 }
 
 impl PbrMaps {
-    pub(crate) fn to_params(
+    pub(crate) fn into_params(
         self,
         map_default: &Texture<[f32; 4]>,
     ) -> PbrMapParams {
@@ -69,10 +69,10 @@ pub(crate) enum PsoData {
     },
 }
 
-impl MaterialType {
+impl Material {
     pub(crate) fn to_pso_data(&self) -> PsoData {
         match *self {
-            MaterialType::Pbr(ref material) => {
+            Material::Pbr(ref material) => {
                 let mut pbr_flags = PbrFlags::empty();
                 if material.base_color_map.is_some() {
                     pbr_flags.insert(BASE_COLOR_MAP);
@@ -113,37 +113,37 @@ impl MaterialType {
                     params: pbr_params,
                 }
             }
-            MaterialType::Basic(ref params) => PsoData::Basic {
+            Material::Basic(ref params) => PsoData::Basic {
                 color: params.color,
                 map: params.map.clone(),
                 param0: 0.0,
             },
-            MaterialType::CustomBasic(ref params) => PsoData::Basic {
+            Material::CustomBasic(ref params) => PsoData::Basic {
                 color: params.color,
                 map: params.map.clone(),
                 param0: 0.0,
             },
-            MaterialType::Line(ref params) => PsoData::Basic {
+            Material::Line(ref params) => PsoData::Basic {
                 color: params.color,
                 map: None,
                 param0: 0.0,
             },
-            MaterialType::Wireframe(ref params) => PsoData::Basic {
+            Material::Wireframe(ref params) => PsoData::Basic {
                 color: params.color,
                 map: None,
                 param0: 0.0,
             },
-            MaterialType::Lambert(ref params) => PsoData::Basic {
+            Material::Lambert(ref params) => PsoData::Basic {
                 color: params.color,
                 map: None,
                 param0: if params.flat { 0.0 } else { 1.0 },
             },
-            MaterialType::Phong(ref params) => PsoData::Basic {
+            Material::Phong(ref params) => PsoData::Basic {
                 color: params.color,
                 map: None,
                 param0: params.glossiness,
             },
-            MaterialType::Sprite(ref params) => PsoData::Basic {
+            Material::Sprite(ref params) => PsoData::Basic {
                 color: !0,
                 map: Some(params.map.clone()),
                 param0: 0.0,

--- a/src/render/pso_data.rs
+++ b/src/render/pso_data.rs
@@ -1,0 +1,163 @@
+use color;
+use gfx::handle as h;
+use material::MaterialType;
+use render::{BackendResources, PbrParams};
+use std::mem;
+use texture::Texture;
+
+bitflags! {
+    struct PbrFlags: i32 {
+        const BASE_COLOR_MAP         = 1 << 0;
+        const NORMAL_MAP             = 1 << 1;
+        const METALLIC_ROUGHNESS_MAP = 1 << 2;
+        const EMISSIVE_MAP           = 1 << 3;
+        const OCCLUSION_MAP          = 1 << 4;
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct PbrMaps {
+    base_color: Option<Texture<[f32; 4]>>,
+    normal: Option<Texture<[f32; 4]>>,
+    emissive: Option<Texture<[f32; 4]>>,
+    metallic_roughness: Option<Texture<[f32; 4]>>,
+    occlusion: Option<Texture<[f32; 4]>>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct PbrMapParams {
+    pub(crate) base_color: (
+        h::ShaderResourceView<BackendResources, [f32; 4]>,
+        h::Sampler<BackendResources>,
+    ),
+    pub(crate) normal: (
+        h::ShaderResourceView<BackendResources, [f32; 4]>,
+        h::Sampler<BackendResources>,
+    ),
+    pub(crate) emissive: (
+        h::ShaderResourceView<BackendResources, [f32; 4]>,
+        h::Sampler<BackendResources>,
+    ),
+    pub(crate) metallic_roughness: (
+        h::ShaderResourceView<BackendResources, [f32; 4]>,
+        h::Sampler<BackendResources>,
+    ),
+    pub(crate) occlusion: (
+        h::ShaderResourceView<BackendResources, [f32; 4]>,
+        h::Sampler<BackendResources>,
+    ),
+}
+
+impl PbrMaps {
+    pub(crate) fn to_params(
+        self,
+        map_default: &Texture<[f32; 4]>,
+    ) -> PbrMapParams {
+        PbrMapParams {
+            base_color: self.base_color.as_ref().unwrap_or(map_default).to_param(),
+            normal: self.normal.as_ref().unwrap_or(map_default).to_param(),
+            emissive: self.emissive.as_ref().unwrap_or(map_default).to_param(),
+            metallic_roughness: self.metallic_roughness
+                .as_ref()
+                .unwrap_or(map_default)
+                .to_param(),
+            occlusion: self.occlusion.as_ref().unwrap_or(map_default).to_param(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum PsoData {
+    Pbr {
+        params: PbrParams,
+        maps: PbrMaps,
+    },
+    Basic {
+        color: u32,
+        param0: f32,
+        map: Option<Texture<[f32; 4]>>,
+    },
+}
+
+impl MaterialType {
+    pub(crate) fn to_pso_data(&self) -> PsoData {
+        match *self {
+            MaterialType::Pbr(ref material) => {
+                let mut pbr_flags = PbrFlags::empty();
+                if material.base_color_map.is_some() {
+                    pbr_flags.insert(BASE_COLOR_MAP);
+                }
+                if material.normal_map.is_some() {
+                    pbr_flags.insert(NORMAL_MAP);
+                }
+                if material.metallic_roughness_map.is_some() {
+                    pbr_flags.insert(METALLIC_ROUGHNESS_MAP);
+                }
+                if material.emissive_map.is_some() {
+                    pbr_flags.insert(EMISSIVE_MAP);
+                }
+                if material.occlusion_map.is_some() {
+                    pbr_flags.insert(OCCLUSION_MAP);
+                }
+                let bcf = color::to_linear_rgb(material.base_color_factor);
+                let emf = color::to_linear_rgb(material.emissive_factor);
+                let pbr_params = PbrParams {
+                    base_color_factor: [bcf[0], bcf[1], bcf[2], material.base_color_alpha],
+                    camera: [0.0, 0.0, 1.0],
+                    emissive_factor: [emf[0], emf[1], emf[2]],
+                    metallic_roughness: [material.metallic_factor, material.roughness_factor],
+                    normal_scale: material.normal_scale,
+                    occlusion_strength: material.occlusion_strength,
+                    pbr_flags: pbr_flags.bits(),
+                    _padding0: unsafe { mem::uninitialized() },
+                    _padding1: unsafe { mem::uninitialized() },
+                };
+                PsoData::Pbr {
+                    maps: PbrMaps {
+                        base_color: material.base_color_map.clone(),
+                        normal: material.normal_map.clone(),
+                        emissive: material.emissive_map.clone(),
+                        metallic_roughness: material.metallic_roughness_map.clone(),
+                        occlusion: material.occlusion_map.clone(),
+                    },
+                    params: pbr_params,
+                }
+            }
+            MaterialType::Basic(ref params) => PsoData::Basic {
+                color: params.color,
+                map: params.map.clone(),
+                param0: 0.0,
+            },
+            MaterialType::CustomBasic(ref params) => PsoData::Basic {
+                color: params.color,
+                map: params.map.clone(),
+                param0: 0.0,
+            },
+            MaterialType::Line(ref params) => PsoData::Basic {
+                color: params.color,
+                map: None,
+                param0: 0.0,
+            },
+            MaterialType::Wireframe(ref params) => PsoData::Basic {
+                color: params.color,
+                map: None,
+                param0: 0.0,
+            },
+            MaterialType::Lambert(ref params) => PsoData::Basic {
+                color: params.color,
+                map: None,
+                param0: if params.flat { 0.0 } else { 1.0 },
+            },
+            MaterialType::Phong(ref params) => PsoData::Basic {
+                color: params.color,
+                map: None,
+                param0: params.glossiness,
+            },
+            MaterialType::Sprite(ref params) => PsoData::Basic {
+                color: !0,
+                map: Some(params.map.clone()),
+                param0: 0.0,
+            },
+        }
+    }
+}

--- a/src/render/pso_data.rs
+++ b/src/render/pso_data.rs
@@ -5,6 +5,11 @@ use render::{BackendResources, PbrParams};
 use std::mem;
 use texture::Texture;
 
+type MapParam = (
+    h::ShaderResourceView<BackendResources, [f32; 4]>,
+    h::Sampler<BackendResources>,
+);
+
 bitflags! {
     struct PbrFlags: i32 {
         const BASE_COLOR_MAP         = 1 << 0;
@@ -26,26 +31,11 @@ pub(crate) struct PbrMaps {
 
 #[derive(Clone, Debug)]
 pub(crate) struct PbrMapParams {
-    pub(crate) base_color: (
-        h::ShaderResourceView<BackendResources, [f32; 4]>,
-        h::Sampler<BackendResources>,
-    ),
-    pub(crate) normal: (
-        h::ShaderResourceView<BackendResources, [f32; 4]>,
-        h::Sampler<BackendResources>,
-    ),
-    pub(crate) emissive: (
-        h::ShaderResourceView<BackendResources, [f32; 4]>,
-        h::Sampler<BackendResources>,
-    ),
-    pub(crate) metallic_roughness: (
-        h::ShaderResourceView<BackendResources, [f32; 4]>,
-        h::Sampler<BackendResources>,
-    ),
-    pub(crate) occlusion: (
-        h::ShaderResourceView<BackendResources, [f32; 4]>,
-        h::Sampler<BackendResources>,
-    ),
+    pub(crate) base_color: MapParam,
+    pub(crate) normal: MapParam,
+    pub(crate) emissive: MapParam,
+    pub(crate) metallic_roughness: MapParam,
+    pub(crate) occlusion: MapParam,
 }
 
 impl PbrMaps {

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -1,6 +1,7 @@
 use gfx::handle as h;
 use render::BackendResources;
 use std::path::Path;
+use util;
 
 use mint;
 
@@ -11,12 +12,15 @@ pub use gfx::texture::{FilterMethod, WrapMode};
 pub struct Sampler(pub h::Sampler<BackendResources>);
 
 /// An image applied (mapped) to the surface of a shape or polygon.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Derivative)]
+#[derivative(Clone, Debug, PartialEq, Eq(bound = "T: PartialEq"), Hash(bound = ""))]
 pub struct Texture<T> {
     view: h::ShaderResourceView<BackendResources, T>,
     sampler: h::Sampler<BackendResources>,
     total_size: [u32; 2],
+    #[derivative(Hash(hash_with = "util::hash_f32_slice"))]
     tex0: [f32; 2],
+    #[derivative(Hash(hash_with = "util::hash_f32_slice"))]
     tex1: [f32; 2],
 }
 
@@ -31,7 +35,10 @@ impl<T> Texture<T> {
             sampler,
             total_size,
             tex0: [0.0; 2],
-            tex1: [total_size[0] as f32, total_size[1] as f32],
+            tex1: [
+                total_size[0] as f32,
+                total_size[1] as f32,
+            ],
         }
     }
 

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -1,9 +1,10 @@
-use gfx::handle as h;
-use render::BackendResources;
 use std::path::Path;
-use util;
 
+use gfx::handle as h;
 use mint;
+
+use render::BackendResources;
+use util;
 
 pub use gfx::texture::{FilterMethod, WrapMode};
 
@@ -18,10 +19,8 @@ pub struct Texture<T> {
     view: h::ShaderResourceView<BackendResources, T>,
     sampler: h::Sampler<BackendResources>,
     total_size: [u32; 2],
-    #[derivative(Hash(hash_with = "util::hash_f32_slice"))]
-    tex0: [f32; 2],
-    #[derivative(Hash(hash_with = "util::hash_f32_slice"))]
-    tex1: [f32; 2],
+    #[derivative(Hash(hash_with = "util::hash_f32_slice"))] tex0: [f32; 2],
+    #[derivative(Hash(hash_with = "util::hash_f32_slice"))] tex1: [f32; 2],
 }
 
 impl<T> Texture<T> {
@@ -35,10 +34,7 @@ impl<T> Texture<T> {
             sampler,
             total_size,
             tex0: [0.0; 2],
-            tex1: [
-                total_size[0] as f32,
-                total_size[1] as f32,
-            ],
+            tex1: [total_size[0] as f32, total_size[1] as f32],
         }
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,12 +14,18 @@ pub fn read_file_to_string<P: AsRef<path::Path>>(path: P) -> io::Result<String> 
 }
 
 /// Hash f32 value using its bit interpretation.
-pub fn hash_f32<H: Hasher>(value: &f32, state: &mut H) {
+pub fn hash_f32<H: Hasher>(
+    value: &f32,
+    state: &mut H,
+) {
     value.to_bits().hash(state);
 }
 
 /// Hash slice of floats using its bit interpretation.
-pub fn hash_f32_slice<H: Hasher>(value: &[f32], state: &mut H) {
+pub fn hash_f32_slice<H: Hasher>(
+    value: &[f32],
+    state: &mut H,
+) {
     for element in value {
         element.to_bits().hash(state);
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,7 @@
 //! Internal utility functions.
 
 use std::{fs, io, path};
+use std::hash::{Hash, Hasher};
 
 /// Reads the entire contents of a file into a `String`.
 pub fn read_file_to_string<P: AsRef<path::Path>>(path: P) -> io::Result<String> {
@@ -10,4 +11,16 @@ pub fn read_file_to_string<P: AsRef<path::Path>>(path: P) -> io::Result<String> 
     let mut contents = String::with_capacity(len);
     let _ = io::BufReader::new(file).read_to_string(&mut contents)?;
     Ok(contents)
+}
+
+/// Hash f32 value using its bit interpretation.
+pub fn hash_f32<H: Hasher>(value: &f32, state: &mut H) {
+    value.to_bits().hash(state);
+}
+
+/// Hash slice of floats using its bit interpretation.
+pub fn hash_f32_slice<H: Hasher>(value: &[f32], state: &mut H) {
+    for element in value {
+        element.to_bits().hash(state);
+    }
 }


### PR DESCRIPTION
fixes #37 

Q&A:
## Insanity? 
No, just auto instancing support. *(I'm lying, it's crazy)*
## What have you done?
Short list:
- All shaders were modified - no more `Locals`, just vertex attributes.
- ~~`Material` enum was renamed to `MaterialType`, made private, added new `Material` struct.
Why? Because I need UIDs to group meshes in renderer.~~
- Huge refactoring in the `render` module in order to reduce code duplication for both instanced and regular rendering.
- ~~`mesh_instance*` was renamed to `duplicate_mesh*`. Reason - you can't change material for mesh with instancing support. (Well, actually you can, but you will lose optimization. Perhaps I should keep this method?)~~

## Worth it?
Totally! In group example, performance have increased from 14 to stable 60 FPS (in release mode).

Some things looks really weird, so ask me please.
Renderer now looks like a total mess, but I would like to continue my work on it.
