### PR TITLE
Fix URL for car screenshot in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If you a looking for something simple to prototype 3D graphics with, you found i
 ## Screenshots
 
 ![Aviator](examples/aviator/shot.png)
-![CarObj](test_data/obj-car.png)
+![CarObj](https://raw.githubusercontent.com/three-rs/example-data/5d821bc9647a8db26888f8dd286f318eaabd2a52/obj-car.png)
 
 ## Motivation and Goals
 


### PR DESCRIPTION
Fixes #146

I opted to use the fully-qualified URL (including the commit hash) for the image, which should ensure that the link stays valid even if the image is moved or deleted in a later commit.