### PR TITLE
Node tree rewrite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ cgmath = { version = "0.15", features = ["mint"] }
 derivative = "1.0"
 froggy = "0.4.4"
 genmesh = "0.5"
-gfx = "0.16"
+gfx = "0.16.3"
 gfx_glyph = "0.7"
 gltf = { features = ["names"], version = "0.9.2" }
 gltf-importer = { features = ["names"], version = "0.9.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ exclude = ["doc", "bors.toml", ".travis.yml", "test_data"]
 
 [lib]
 
+[profile.release]
+debug = true
+
 [features]
 default = ["opengl"]
 "opengl" = ["gfx_device_gl", "gfx_window_glutin", "glutin"]

--- a/examples/anim.rs
+++ b/examples/anim.rs
@@ -119,9 +119,9 @@ fn main() {
         );
     }
 
-    let mut mesh = win.factory
+    let mesh = win.factory
         .mesh_dynamic(geom, three::material::Wireframe { color: 0xFFFFFF });
-    mesh.set_parent(&win.scene);
+    win.scene.add(&mesh);
 
     let mut shape = 0;
     let (mut name0, mut name1) = ("fly00".to_string(), "fly01".to_string());

--- a/examples/anim.rs
+++ b/examples/anim.rs
@@ -99,7 +99,7 @@ fn make_geometry() -> three::Geometry {
 
 fn main() {
     let mut win = three::Window::new("Three-rs mesh blending example");
-    let mut cam = win.factory.perspective_camera(60.0, 1.0 .. 1000.0);
+    let cam = win.factory.perspective_camera(60.0, 1.0 .. 1000.0);
     cam.look_at(
         [100.0, 0.0, 100.0],
         [0.0, 0.0, 30.0],

--- a/examples/aviator/main.rs
+++ b/examples/aviator/main.rs
@@ -27,20 +27,20 @@ fn main() {
 
     let mut cam = win.factory.perspective_camera(60.0, 1.0 .. 1000.0);
     cam.set_position([0.0, 100.0, 200.0]);
-    cam.set_parent(&win.scene);
+    win.scene.add(&cam);
 
     //TODO: win.scene.fog = Some(three::Fog::new(...));
     //TODO: Phong materials
 
-    let mut hemi_light = win.factory.hemisphere_light(0xaaaaaa, 0x000000, 0.9);
-    hemi_light.set_parent(&win.scene);
+    let hemi_light = win.factory.hemisphere_light(0xaaaaaa, 0x000000, 0.9);
+    win.scene.add(&hemi_light);
     let mut dir_light = win.factory.directional_light(0xffffff, 0.9);
     dir_light.look_at([150.0, 350.0, 350.0], [0.0, 0.0, 0.0], None);
     let shadow_map = win.factory.shadow_map(2048, 2048);
     dir_light.set_shadow(shadow_map, 400.0, 1.0 .. 1000.0);
-    dir_light.set_parent(&win.scene);
-    let mut ambient_light = win.factory.ambient_light(0xdc8874, 0.5);
-    ambient_light.set_parent(&win.scene);
+    win.scene.add(&dir_light);
+    let ambient_light = win.factory.ambient_light(0xdc8874, 0.5);
+    win.scene.add(&ambient_light);
 
     let mut sea = {
         let geo = three::Geometry::cylinder(600.0, 600.0, 800.0, 40);
@@ -52,17 +52,17 @@ fn main() {
     };
     let sea_base_q = cgmath::Quaternion::from_angle_x(-cgmath::Rad::turn_div_4());
     sea.set_transform([0.0, -600.0, 0.0], sea_base_q, 1.0);
-    sea.set_parent(&win.scene);
+    win.scene.add(&sea);
 
     let mut sky = sky::Sky::new(&mut rng, &mut win.factory);
     sky.group.set_position([0.0, -600.0, 0.0]);
-    sky.group.set_parent(&win.scene);
+    win.scene.add(&sky.group);
 
     let mut airplane = plane::AirPlane::new(&mut win.factory);
     airplane
         .group
         .set_transform([0.0, 100.0, 0.0], [0.0, 0.0, 0.0, 1.0], 0.25);
-    airplane.group.set_parent(&win.scene);
+    win.scene.add(&airplane.group);
 
     let timer = win.input.time();
     while win.update() && !win.input.hit(three::KEY_ESCAPE) {

--- a/examples/aviator/main.rs
+++ b/examples/aviator/main.rs
@@ -25,7 +25,7 @@ fn main() {
     let mut win = three::Window::new("Three-rs Aviator demo");
     win.scene.background = three::Background::Color(COLOR_BACKGROUND);
 
-    let mut cam = win.factory.perspective_camera(60.0, 1.0 .. 1000.0);
+    let cam = win.factory.perspective_camera(60.0, 1.0 .. 1000.0);
     cam.set_position([0.0, 100.0, 200.0]);
     win.scene.add(&cam);
 
@@ -42,7 +42,7 @@ fn main() {
     let ambient_light = win.factory.ambient_light(0xdc8874, 0.5);
     win.scene.add(&ambient_light);
 
-    let mut sea = {
+    let sea = {
         let geo = three::Geometry::cylinder(600.0, 600.0, 800.0, 40);
         let material = three::material::Lambert {
             color: COLOR_BLUE,
@@ -54,7 +54,7 @@ fn main() {
     sea.set_transform([0.0, -600.0, 0.0], sea_base_q, 1.0);
     win.scene.add(&sea);
 
-    let mut sky = sky::Sky::new(&mut rng, &mut win.factory);
+    let sky = sky::Sky::new(&mut rng, &mut win.factory);
     sky.group.set_position([0.0, -600.0, 0.0]);
     win.scene.add(&sky.group);
 

--- a/examples/aviator/plane.rs
+++ b/examples/aviator/plane.rs
@@ -17,9 +17,9 @@ pub struct AirPlane {
 
 impl AirPlane {
     pub fn new(factory: &mut three::Factory) -> Self {
-        let group = factory.group();
+        let mut group = factory.group();
 
-        let mut cockpit = {
+        let cockpit = {
             let mut geo = three::Geometry::cuboid(80.0, 50.0, 50.0);
             for v in geo.base_shape.vertices.iter_mut() {
                 if v.x < 0.0 {
@@ -35,7 +35,7 @@ impl AirPlane {
                 },
             )
         };
-        cockpit.set_parent(&group);
+        group.add(&cockpit);
 
         let mut engine = factory.mesh(
             three::Geometry::cuboid(20.0, 50.0, 50.0),
@@ -45,7 +45,7 @@ impl AirPlane {
             },
         );
         engine.set_position([40.0, 0.0, 0.0]);
-        engine.set_parent(&group);
+        group.add(&engine);
 
         let mut tail = factory.mesh(
             three::Geometry::cuboid(15.0, 20.0, 5.0),
@@ -55,28 +55,28 @@ impl AirPlane {
             },
         );
         tail.set_position([-35.0, 25.0, 0.0]);
-        tail.set_parent(&group);
+        group.add(&tail);
 
-        let mut wing = factory.mesh(
+        let wing = factory.mesh(
             three::Geometry::cuboid(40.0, 8.0, 150.0),
             three::material::Lambert {
                 color: COLOR_RED,
                 flat: false,
             },
         );
-        wing.set_parent(&group);
+        group.add(&wing);
 
         let mut propeller_group = factory.group();
         propeller_group.set_position([50.0, 0.0, 0.0]);
-        propeller_group.set_parent(&group);
-        let mut propeller = factory.mesh(
+        group.add(&propeller_group);
+        let propeller = factory.mesh(
             three::Geometry::cuboid(20.0, 10.0, 10.0),
             three::material::Lambert {
                 color: COLOR_BROWN,
                 flat: false,
             },
         );
-        propeller.set_parent(&propeller_group);
+        propeller_group.add(&propeller);
         let mut blade = factory.mesh(
             three::Geometry::cuboid(1.0, 100.0, 20.0),
             three::material::Lambert {
@@ -85,7 +85,7 @@ impl AirPlane {
             },
         );
         blade.set_position([8.0, 0.0, 0.0]);
-        blade.set_parent(&propeller_group);
+        propeller_group.add(&blade);
 
         AirPlane {
             group,

--- a/examples/aviator/plane.rs
+++ b/examples/aviator/plane.rs
@@ -17,7 +17,7 @@ pub struct AirPlane {
 
 impl AirPlane {
     pub fn new(factory: &mut three::Factory) -> Self {
-        let mut group = factory.group();
+        let group = factory.group();
 
         let cockpit = {
             let mut geo = three::Geometry::cuboid(80.0, 50.0, 50.0);
@@ -37,7 +37,7 @@ impl AirPlane {
         };
         group.add(&cockpit);
 
-        let mut engine = factory.mesh(
+        let engine = factory.mesh(
             three::Geometry::cuboid(20.0, 50.0, 50.0),
             three::material::Lambert {
                 color: COLOR_WHITE,
@@ -47,7 +47,7 @@ impl AirPlane {
         engine.set_position([40.0, 0.0, 0.0]);
         group.add(&engine);
 
-        let mut tail = factory.mesh(
+        let tail = factory.mesh(
             three::Geometry::cuboid(15.0, 20.0, 5.0),
             three::material::Lambert {
                 color: COLOR_RED,
@@ -66,7 +66,7 @@ impl AirPlane {
         );
         group.add(&wing);
 
-        let mut propeller_group = factory.group();
+        let propeller_group = factory.group();
         propeller_group.set_position([50.0, 0.0, 0.0]);
         group.add(&propeller_group);
         let propeller = factory.mesh(
@@ -77,7 +77,7 @@ impl AirPlane {
             },
         );
         propeller_group.add(&propeller);
-        let mut blade = factory.mesh(
+        let blade = factory.mesh(
             three::Geometry::cuboid(1.0, 100.0, 20.0),
             three::material::Lambert {
                 color: COLOR_BROWN_DARK,

--- a/examples/aviator/sky.rs
+++ b/examples/aviator/sky.rs
@@ -7,20 +7,17 @@ use three::{self, Object};
 
 use COLOR_WHITE;
 
-struct Cloud {
-    group: three::Group,
-    meshes: Vec<three::Mesh>,
+
+pub struct Sky {
+    pub group: three::Group,
 }
 
-impl Cloud {
-    fn new<R: Rng>(
+impl Sky {
+    fn make_cloud<R: Rng>(
         rng: &mut R,
         factory: &mut three::Factory,
-    ) -> Self {
-        let mut cloud = Cloud {
-            group: factory.group(),
-            meshes: Vec::new(),
-        };
+    ) -> three::Group {
+        let mut group = factory.group();
         let geo = three::Geometry::cuboid(20.0, 20.0, 20.0);
         let material = three::material::Lambert {
             color: COLOR_WHITE,
@@ -40,31 +37,20 @@ impl Cloud {
                 q,
                 rng.gen_range(0.1, 1.0),
             );
-            m.set_parent(&cloud.group);
-            cloud.meshes.push(m);
+            group.add(&m);
         }
-        cloud
+        group
     }
-}
 
-pub struct Sky {
-    pub group: three::Group,
-    clouds: Vec<Cloud>,
-}
-
-impl Sky {
     pub fn new<R: Rng>(
         rng: &mut R,
         factory: &mut three::Factory,
     ) -> Self {
-        let mut sky = Sky {
-            group: factory.group(),
-            clouds: Vec::new(),
-        };
+        let mut group = factory.group();
         let num = 20i32;
         let step_angle = PI * 2.0 / num as f32;
         for i in 0 .. num {
-            let mut c = Cloud::new(rng, factory);
+            let mut cloud = Self::make_cloud(rng, factory);
             let angle = cgmath::Rad(i as f32 * step_angle);
             let dist = rng.gen_range(750.0, 950.0);
             let pos = [
@@ -73,10 +59,9 @@ impl Sky {
                 rng.gen_range(-800.0, -400.0),
             ];
             let q = cgmath::Quaternion::from_angle_z(angle + cgmath::Rad::turn_div_4());
-            c.group.set_transform(pos, q, rng.gen_range(1.0, 3.0));
-            c.group.set_parent(&sky.group);
-            sky.clouds.push(c);
+            cloud.set_transform(pos, q, rng.gen_range(1.0, 3.0));
+            group.add(&cloud);
         }
-        sky
+        Sky { group }
     }
 }

--- a/examples/aviator/sky.rs
+++ b/examples/aviator/sky.rs
@@ -17,7 +17,7 @@ impl Sky {
         rng: &mut R,
         factory: &mut three::Factory,
     ) -> three::Group {
-        let mut group = factory.group();
+        let group = factory.group();
         let geo = three::Geometry::cuboid(20.0, 20.0, 20.0);
         let material = three::material::Lambert {
             color: COLOR_WHITE,
@@ -25,7 +25,7 @@ impl Sky {
         };
         let template = factory.mesh(geo, material.clone());
         for i in 0i32 .. rng.gen_range(3, 6) {
-            let mut m = factory.mesh_instance(&template);
+            let m = factory.mesh_instance(&template);
             let rot: cgmath::Quaternion<f32> = rng.gen();
             let q = rot.normalize();
             m.set_transform(
@@ -46,11 +46,11 @@ impl Sky {
         rng: &mut R,
         factory: &mut three::Factory,
     ) -> Self {
-        let mut group = factory.group();
+        let group = factory.group();
         let num = 20i32;
         let step_angle = PI * 2.0 / num as f32;
         for i in 0 .. num {
-            let mut cloud = Self::make_cloud(rng, factory);
+            let cloud = Self::make_cloud(rng, factory);
             let angle = cgmath::Rad(i as f32 * step_angle);
             let dist = rng.gen_range(750.0, 950.0);
             let pos = [

--- a/examples/gltf-animation.rs
+++ b/examples/gltf-animation.rs
@@ -6,13 +6,13 @@ fn main() {
     let mut window = three::Window::new("Three-rs glTF animation example");
     let mut light = window.factory.directional_light(0xFFFFFF, 0.4);
     light.look_at([1.0, 1.0, 1.0], [0.0, 0.0, 0.0], None);
-    light.set_parent(&window.scene);
+    window.scene.add(&light);
     window.scene.background = three::Background::Color(0xC6F0FF);
 
     let default = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/BoxAnimated.gltf");
     let path = std::env::args().nth(1).unwrap_or(default.into());
-    let mut gltf = window.factory.load_gltf(&path);
-    gltf.group.set_parent(&window.scene);
+    let gltf = window.factory.load_gltf(&path);
+    window.scene.add(&gltf.group);
 
     let mut mixer = three::animation::Mixer::new();
     for clip in gltf.clips {

--- a/examples/gltf-animation.rs
+++ b/examples/gltf-animation.rs
@@ -4,7 +4,7 @@ use three::Object;
 
 fn main() {
     let mut window = three::Window::new("Three-rs glTF animation example");
-    let mut light = window.factory.directional_light(0xFFFFFF, 0.4);
+    let light = window.factory.directional_light(0xFFFFFF, 0.4);
     light.look_at([1.0, 1.0, 1.0], [0.0, 0.0, 0.0], None);
     window.scene.add(&light);
     window.scene.background = three::Background::Color(0xC6F0FF);
@@ -19,7 +19,7 @@ fn main() {
         mixer.action(clip);
     }
 
-    let mut camera = window.factory.perspective_camera(60.0, 0.1 .. 10.0);
+    let camera = window.factory.perspective_camera(60.0, 0.1 .. 10.0);
     camera.set_position([0.0, 1.0, 5.0]);
     while window.update() && !window.input.hit(three::KEY_ESCAPE) {
         mixer.update(window.input.delta_time());

--- a/examples/gltf.rs
+++ b/examples/gltf.rs
@@ -6,19 +6,19 @@ fn main() {
     let mut win = three::Window::new("Three-rs glTF example");
     let mut light = win.factory.directional_light(0xFFFFFF, 7.0);
     light.look_at([1.0, 1.0, 1.0], [0.0, 0.0, 0.0], None);
-    light.set_parent(&win.scene);
+    win.scene.add(&light);
     win.scene.background = three::Background::Color(0xC6F0FF);
 
     let default = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/Lantern.gltf");
     let path = std::env::args().nth(1).unwrap_or(default.into());
     let mut gltf = win.factory.load_gltf(&path);
-    gltf.group.set_parent(&win.scene);
+    win.scene.add(&gltf.group);
 
-    let mut cam = if gltf.cameras.len() > 0 {
+    let cam = if gltf.cameras.len() > 0 {
         gltf.cameras.swap_remove(0)
     } else {
-        let mut default = win.factory.perspective_camera(60.0, 0.001 .. 100.0);
-        default.set_parent(&win.scene);
+        let default = win.factory.perspective_camera(60.0, 0.001 .. 100.0);
+        win.scene.add(&default);
         default
     };
 
@@ -36,7 +36,10 @@ fn main() {
         win.scene.background = three::Background::Skybox(skybox);
     }
 
-    let init = cam.sync(&win.scene).world_transform;
+    let init = win.scene
+        .sync_guard()
+        .resolve(&cam)
+        .transform; //TODO: world transform
     let mut controls = three::controls::FirstPerson::builder(&cam)
         .position(init.position)
         .move_speed(4.0)

--- a/examples/gltf.rs
+++ b/examples/gltf.rs
@@ -4,7 +4,7 @@ use three::Object;
 
 fn main() {
     let mut win = three::Window::new("Three-rs glTF example");
-    let mut light = win.factory.directional_light(0xFFFFFF, 7.0);
+    let light = win.factory.directional_light(0xFFFFFF, 7.0);
     light.look_at([1.0, 1.0, 1.0], [0.0, 0.0, 0.0], None);
     win.scene.add(&light);
     win.scene.background = three::Background::Color(0xC6F0FF);

--- a/examples/gltf.rs
+++ b/examples/gltf.rs
@@ -38,8 +38,8 @@ fn main() {
 
     let init = win.scene
         .sync_guard()
-        .resolve(&cam)
-        .transform; //TODO: world transform
+        .resolve_world(&cam)
+        .transform;
     let mut controls = three::controls::FirstPerson::builder(&cam)
         .position(init.position)
         .move_speed(4.0)

--- a/examples/group.rs
+++ b/examples/group.rs
@@ -102,9 +102,19 @@ fn create_cubes(
     list
 }
 
-const COLORS: [three::Color; 6] = [0xffff80, 0x8080ff, 0x80ff80, 0xff8080, 0x80ffff, 0xff80ff];
-
-const SPEEDS: [f32; 6] = [0.7, -1.0, 1.3, -1.6, 1.9, -2.2];
+struct LevelDesc {
+    color: three::Color,
+    speed: f32, // in radians per second
+}
+const LEVELS: &[LevelDesc] = &[
+    LevelDesc { color: 0xffff80, speed: 0.7 },
+    LevelDesc { color: 0x8080ff, speed: -1.0 },
+    LevelDesc { color: 0x80ff80, speed: 1.3 },
+    LevelDesc { color: 0xff8080, speed: -1.6 },
+    LevelDesc { color: 0x80ffff, speed: 1.9 },
+    LevelDesc { color: 0xff80ff, speed: -2.2 },
+    //LevelDesc { color: 0x8080ff, speed: 2.5 },
+];
 
 fn main() {
     let mut win = three::Window::new("Three-rs group example");
@@ -117,11 +127,14 @@ fn main() {
     light.set_position([0.0, -10.0, 10.0]);
     win.scene.add(&light);
 
-    let materials: Vec<_> = COLORS
+    let materials = LEVELS
         .iter()
-        .map(|&color| three::material::Lambert { color, flat: false })
-        .collect();
-    let levels: Vec<_> = SPEEDS.iter().map(|&speed| Level { speed }).collect();
+        .map(|l| three::material::Lambert { color: l.color, flat: false })
+        .collect::<Vec<_>>();
+    let levels = LEVELS
+        .iter()
+        .map(|l| Level { speed: l.speed })
+        .collect::<Vec<_>>();
     let mut cubes = create_cubes(&mut win.factory, &materials, &levels);
     win.scene.add(&cubes[0].group);
 

--- a/examples/group.rs
+++ b/examples/group.rs
@@ -27,7 +27,7 @@ fn create_cubes(
     }
 
     let root = {
-        let mut group = factory.group();
+        let group = factory.group();
         let mesh = factory.mesh(geometry.clone(), materials[0].clone());
         group.set_position([0.0, 0.0, 1.0]);
         group.set_scale(2.0);
@@ -78,7 +78,7 @@ fn create_cubes(
     while let Some(next) = stack.pop() {
         for child in &children {
             let mat = materials[next.mat_id].clone();
-            let mut cube = Cube {
+            let cube = Cube {
                 group: factory.group(),
                 mesh: factory.mesh_instance_with_material(&list[0].mesh, mat),
                 level_id: next.lev_id,
@@ -110,10 +110,10 @@ fn main() {
     let mut win = three::Window::new("Three-rs group example");
     win.scene.background = three::Background::Color(0x204060);
 
-    let mut cam = win.factory.perspective_camera(60.0, 1.0 .. 100.0);
+    let cam = win.factory.perspective_camera(60.0, 1.0 .. 100.0);
     cam.look_at([-1.8, -8.0, 7.0], [0.0, 0.0, 3.5], None);
 
-    let mut light = win.factory.point_light(0xffffff, 1.0);
+    let light = win.factory.point_light(0xffffff, 1.0);
     light.set_position([0.0, -10.0, 10.0]);
     win.scene.add(&light);
 

--- a/examples/group.rs
+++ b/examples/group.rs
@@ -28,10 +28,10 @@ fn create_cubes(
 
     let root = {
         let mut group = factory.group();
-        let mut mesh = factory.mesh(geometry.clone(), materials[0].clone());
+        let mesh = factory.mesh(geometry.clone(), materials[0].clone());
         group.set_position([0.0, 0.0, 1.0]);
         group.set_scale(2.0);
-        mesh.set_parent(&group);
+        group.add(&mesh);
         Cube {
             group,
             mesh,
@@ -86,8 +86,8 @@ fn create_cubes(
             };
             let p: mint::Vector3<f32> = child.disp.into();
             cube.group.set_transform(p, child.rot, child.scale);
-            cube.group.set_parent(&list[next.parent_id].group);
-            cube.mesh.set_parent(&cube.group);
+            list[next.parent_id].group.add(&cube.group);
+            cube.group.add(&cube.mesh);
             if next.mat_id + 1 < materials.len() && next.lev_id + 1 < levels.len() {
                 stack.push(Stack {
                     parent_id: list.len(),
@@ -115,7 +115,7 @@ fn main() {
 
     let mut light = win.factory.point_light(0xffffff, 1.0);
     light.set_position([0.0, -10.0, 10.0]);
-    light.set_parent(&win.scene);
+    win.scene.add(&light);
 
     let materials: Vec<_> = COLORS
         .iter()
@@ -123,7 +123,7 @@ fn main() {
         .collect();
     let levels: Vec<_> = SPEEDS.iter().map(|&speed| Level { speed }).collect();
     let mut cubes = create_cubes(&mut win.factory, &materials, &levels);
-    cubes[0].group.set_parent(&win.scene);
+    win.scene.add(&cubes[0].group);
 
     let font = win.factory.load_font(format!(
         "{}/data/fonts/DejaVuSans.ttf",

--- a/examples/lights.rs
+++ b/examples/lights.rs
@@ -26,8 +26,8 @@ fn main() {
         dir_light.as_mut(),
     ];
     for l in lights.iter_mut() {
-        l.set_parent(&win.scene);
         l.set_visible(false);
+        win.scene.add(l);
     }
 
     let mut sphere = {
@@ -39,7 +39,7 @@ fn main() {
         win.factory.mesh(geometry, material)
     };
     sphere.set_position([0.0, 0.0, 2.5]);
-    sphere.set_parent(&win.scene);
+    win.scene.add(&sphere);
 
     let mut plane = {
         let geometry = three::Geometry::plane(100.0, 100.0);
@@ -50,7 +50,7 @@ fn main() {
         win.factory.mesh(geometry, material)
     };
     plane.set_position([0.0, -30.0, 0.0]);
-    plane.set_parent(&win.scene);
+    win.scene.add(&plane);
 
     let mut light_id = 0i8;
     lights[0].set_visible(true);

--- a/examples/lights.rs
+++ b/examples/lights.rs
@@ -4,7 +4,7 @@ use three::Object;
 
 fn main() {
     let mut win = three::Window::new("Three-rs lights example");
-    let mut cam = win.factory.perspective_camera(45.0, 1.0 .. 50.0);
+    let cam = win.factory.perspective_camera(45.0, 1.0 .. 50.0);
     cam.look_at([-4.0, 15.0, 10.0], [0.0, 0.0, 2.0], None);
 
     let mut hemisphere_light = win.factory.hemisphere_light(0xffffff, 0x8080ff, 0.5);
@@ -30,7 +30,7 @@ fn main() {
         win.scene.add(l);
     }
 
-    let mut sphere = {
+    let sphere = {
         let geometry = three::Geometry::uv_sphere(3.0, 20, 20);
         let material = three::material::Phong {
             color: 0xffA0A0,
@@ -41,7 +41,7 @@ fn main() {
     sphere.set_position([0.0, 0.0, 2.5]);
     win.scene.add(&sphere);
 
-    let mut plane = {
+    let plane = {
         let geometry = three::Geometry::plane(100.0, 100.0);
         let material = three::material::Lambert {
             color: 0xA0ffA0,

--- a/examples/materials.rs
+++ b/examples/materials.rs
@@ -10,7 +10,7 @@ fn main() {
     let mut light = win.factory.point_light(0xffffff, 0.5);
     let mut pos = [0.0, 5.0, 5.0];
     light.set_position(pos);
-    light.set_parent(&win.scene);
+    win.scene.add(&light);
 
     let geometry = three::Geometry::cylinder(1.0, 2.0, 2.0, 5);
     let mut materials: Vec<three::Material> = vec![
@@ -54,7 +54,7 @@ fn main() {
             let offset = 4.0 * (i as f32 + 0.5 - 0.5 * count as f32);
             let mut mesh = win.factory.mesh(geometry.clone(), mat);
             mesh.set_position([offset, 0.0, 0.0]);
-            mesh.set_parent(&win.scene);
+            win.scene.add(&mesh);
             mesh
         })
         .collect();

--- a/examples/materials.rs
+++ b/examples/materials.rs
@@ -4,10 +4,10 @@ use three::Object;
 
 fn main() {
     let mut win = three::Window::new("Three-rs materials example");
-    let mut cam = win.factory.perspective_camera(75.0, 1.0 .. 50.0);
+    let cam = win.factory.perspective_camera(75.0, 1.0 .. 50.0);
     cam.set_position([0.0, 0.0, 10.0]);
 
-    let mut light = win.factory.point_light(0xffffff, 0.5);
+    let light = win.factory.point_light(0xffffff, 0.5);
     let mut pos = [0.0, 5.0, 5.0];
     light.set_position(pos);
     win.scene.add(&light);
@@ -52,7 +52,7 @@ fn main() {
         .enumerate()
         .map(|(i, mat)| {
             let offset = 4.0 * (i as f32 + 0.5 - 0.5 * count as f32);
-            let mut mesh = win.factory.mesh(geometry.clone(), mat);
+            let mesh = win.factory.mesh(geometry.clone(), mat);
             mesh.set_position([offset, 0.0, 0.0]);
             win.scene.add(&mesh);
             mesh

--- a/examples/mesh-update.rs
+++ b/examples/mesh-update.rs
@@ -4,7 +4,7 @@ extern crate three;
 
 use cgmath::prelude::*;
 use std::f32::consts::PI;
-use three::Object;
+
 
 fn make_tetrahedron_geometry() -> three::Geometry {
     let vertices = vec![
@@ -52,7 +52,7 @@ fn main() {
     let material = three::material::Wireframe { color: 0xFFFF00 };
     let mut mesh = win.factory.mesh_dynamic(geometry, material);
     let vertex_count = mesh.vertex_count();
-    mesh.set_parent(&win.scene);
+    win.scene.add(&mesh);
 
     let mut timer = win.input.time();
     let mut vi = 0;

--- a/examples/obj.rs
+++ b/examples/obj.rs
@@ -16,13 +16,13 @@ fn main() {
 
     let mut dir_light = win.factory.directional_light(0xffffff, 0.9);
     dir_light.look_at([15.0, 35.0, 35.0], [0.0, 0.0, 2.0], None);
-    dir_light.set_parent(&win.scene);
+    win.scene.add(&dir_light);
 
     let mut root = win.factory.group();
-    root.set_parent(&win.scene);
+    win.scene.add(&root);
     let (mut group_map, _meshes) = win.factory.load_obj(&path);
     for g in group_map.values_mut() {
-        g.set_parent(&root);
+        root.add(g);
     }
 
     while win.update() && !win.input.hit(three::KEY_ESCAPE) {

--- a/examples/obj.rs
+++ b/examples/obj.rs
@@ -14,11 +14,11 @@ fn main() {
         .target([0.0, 0.0, 0.0])
         .build();
 
-    let mut dir_light = win.factory.directional_light(0xffffff, 0.9);
+    let dir_light = win.factory.directional_light(0xffffff, 0.9);
     dir_light.look_at([15.0, 35.0, 35.0], [0.0, 0.0, 2.0], None);
     win.scene.add(&dir_light);
 
-    let mut root = win.factory.group();
+    let root = win.factory.group();
     win.scene.add(&root);
     let (mut group_map, _meshes) = win.factory.load_obj(&path);
     for g in group_map.values_mut() {

--- a/examples/reload.rs
+++ b/examples/reload.rs
@@ -89,12 +89,12 @@ fn main() {
         .watch(&dir, notify::RecursiveMode::NonRecursive)
         .unwrap();
 
-    let map_path = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/gradient.png");
+    let map_path = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/texture.png");
     let map = win.factory.load_texture(map_path);
     let material = three::material::Sprite { map };
     let mut sprite = win.factory.sprite(material);
     sprite.set_scale(1.0);
-    sprite.set_parent(&win.scene);
+    win.scene.add(&sprite);
 
     let mut reload = true;
     while win.update() && !win.input.hit(three::KEY_ESCAPE) {

--- a/examples/reload.rs
+++ b/examples/reload.rs
@@ -92,7 +92,7 @@ fn main() {
     let map_path = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/texture.png");
     let map = win.factory.load_texture(map_path);
     let material = three::material::Sprite { map };
-    let mut sprite = win.factory.sprite(material);
+    let sprite = win.factory.sprite(material);
     sprite.set_scale(1.0);
     win.scene.add(&sprite);
 

--- a/examples/shapes.rs
+++ b/examples/shapes.rs
@@ -16,7 +16,7 @@ fn main() {
         win.factory.mesh(geometry, material)
     };
     mbox.set_position([-3.0, -3.0, 0.0]);
-    mbox.set_parent(&win.scene);
+    win.scene.add(&mbox);
 
     let mut mcyl = {
         let geometry = three::Geometry::cylinder(1.0, 2.0, 2.0, 5);
@@ -24,7 +24,7 @@ fn main() {
         win.factory.mesh(geometry, material)
     };
     mcyl.set_position([3.0, -3.0, 0.0]);
-    mcyl.set_parent(&win.scene);
+    win.scene.add(&mcyl);
 
     let mut msphere = {
         let geometry = three::Geometry::uv_sphere(2.0, 5, 5);
@@ -32,7 +32,7 @@ fn main() {
         win.factory.mesh(geometry, material)
     };
     msphere.set_position([-3.0, 3.0, 0.0]);
-    msphere.set_parent(&win.scene);
+    win.scene.add(&msphere);
 
     let mut mline = {
         let geometry = three::Geometry::with_vertices(vec![
@@ -44,7 +44,7 @@ fn main() {
         win.factory.mesh(geometry, material)
     };
     mline.set_position([3.0, 3.0, 0.0]);
-    mline.set_parent(&win.scene);
+    win.scene.add(&mline);
 
     let mut angle = cgmath::Rad::zero();
     while win.update() && !win.input.hit(three::KEY_ESCAPE) {

--- a/examples/shapes.rs
+++ b/examples/shapes.rs
@@ -7,10 +7,10 @@ use three::Object;
 
 fn main() {
     let mut win = three::Window::new("Three-rs shapes example");
-    let mut cam = win.factory.perspective_camera(75.0, 1.0 .. 50.0);
+    let cam = win.factory.perspective_camera(75.0, 1.0 .. 50.0);
     cam.set_position([0.0, 0.0, 10.0]);
 
-    let mut mbox = {
+    let mbox = {
         let geometry = three::Geometry::cuboid(3.0, 2.0, 1.0);
         let material = three::material::Wireframe { color: 0x00FF00 };
         win.factory.mesh(geometry, material)
@@ -18,7 +18,7 @@ fn main() {
     mbox.set_position([-3.0, -3.0, 0.0]);
     win.scene.add(&mbox);
 
-    let mut mcyl = {
+    let mcyl = {
         let geometry = three::Geometry::cylinder(1.0, 2.0, 2.0, 5);
         let material = three::material::Wireframe { color: 0xFF0000 };
         win.factory.mesh(geometry, material)
@@ -26,7 +26,7 @@ fn main() {
     mcyl.set_position([3.0, -3.0, 0.0]);
     win.scene.add(&mcyl);
 
-    let mut msphere = {
+    let msphere = {
         let geometry = three::Geometry::uv_sphere(2.0, 5, 5);
         let material = three::material::Wireframe { color: 0xFF0000 };
         win.factory.mesh(geometry, material)
@@ -34,7 +34,7 @@ fn main() {
     msphere.set_position([-3.0, 3.0, 0.0]);
     win.scene.add(&msphere);
 
-    let mut mline = {
+    let mline = {
         let geometry = three::Geometry::with_vertices(vec![
             [-2.0, -1.0, 0.0].into(),
             [0.0, 1.0, 0.0].into(),

--- a/examples/shapes.rs
+++ b/examples/shapes.rs
@@ -34,6 +34,12 @@ fn main() {
     msphere.set_position([-3.0, 3.0, 0.0]);
     win.scene.add(&msphere);
 
+    // test removal from scene
+    win.scene.remove(&mcyl);
+    win.scene.remove(&mbox);
+    win.scene.add(&mcyl);
+    win.scene.add(&mbox);
+
     let mline = {
         let geometry = three::Geometry::with_vertices(vec![
             [-2.0, -1.0, 0.0].into(),

--- a/examples/sprite.rs
+++ b/examples/sprite.rs
@@ -53,7 +53,7 @@ fn main() {
     let material = three::material::Sprite {
         map: win.factory.load_texture(pikachu_path_str),
     };
-    let mut sprite = win.factory.sprite(material);
+    let sprite = win.factory.sprite(material);
     sprite.set_scale(8.0);
     win.scene.add(&sprite);
 

--- a/examples/sprite.rs
+++ b/examples/sprite.rs
@@ -55,7 +55,7 @@ fn main() {
     };
     let mut sprite = win.factory.sprite(material);
     sprite.set_scale(8.0);
-    sprite.set_parent(&win.scene);
+    win.scene.add(&sprite);
 
     let mut anim = Animator {
         cell_size: [96, 96],

--- a/examples/tutorial.rs
+++ b/examples/tutorial.rs
@@ -1,7 +1,5 @@
 extern crate three;
 
-use three::Object;
-
 fn main() {
     let mut window = three::Window::new("Getting started with three-rs");
 
@@ -15,9 +13,8 @@ fn main() {
         color: 0xFFFF00,
         map: None,
     };
-    let mut mesh = window.factory.mesh(geometry, material);
-    mesh.set_parent(&window.scene);
-
+    let mesh = window.factory.mesh(geometry, material);
+    window.scene.add(&mesh);
     window.scene.background = three::Background::Color(0xC6F0FF);
 
     let center = [0.0, 0.0];

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -42,9 +42,8 @@
 //!
 //! ```rust,no_run
 //! # let mut window = three::Window::new("");
-//! use three::Object;
-//! let mut gltf = window.factory.load_gltf("AnimatedScene.gltf");
-//! gltf.group.set_parent(&window.scene);
+//! let gltf = window.factory.load_gltf("AnimatedScene.gltf");
+//! window.scene.add(&gltf.group);
 //! ```
 //!
 //! ### Creating animation actions
@@ -56,11 +55,10 @@
 //! immediately.
 //!
 //! ```rust,no_run
-//! # use three::Object;
 //! # let mut window = three::Window::new("");
 //! # let mut mixer = three::animation::Mixer::new();
-//! # let mut gltf = window.factory.load_gltf("AnimatedScene.gltf");
-//! # gltf.group.set_parent(&window.scene);
+//! # let gltf = window.factory.load_gltf("AnimatedScene.gltf");
+//! # window.scene.add(&gltf.group);
 //! let actions: Vec<three::animation::Action> = gltf.clips
 //!     .into_iter()
 //!     .map(|clip| mixer.action(clip))
@@ -73,12 +71,11 @@
 //! game loop.
 //!
 //! ```rust,no_run
-//! # use three::Object;
 //! # let mut window = three::Window::new("");
 //! # let camera = unimplemented!();
 //! # let mut mixer = three::animation::Mixer::new();
-//! # let mut gltf = window.factory.load_gltf("AnimatedScene.gltf");
-//! # gltf.group.set_parent(&window.scene);
+//! # let gltf = window.factory.load_gltf("AnimatedScene.gltf");
+//! # window.scene.add(&gltf.group);
 //! # let actions: Vec<three::animation::Action> = gltf.clips
 //! #     .into_iter()
 //! #     .map(|clip| mixer.action(clip))

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -58,7 +58,10 @@
 
 use cgmath;
 use mint;
+
+use hub::{Hub, SubNode};
 use object;
+
 use std::ops;
 
 /// The Z values of the near and far clipping planes of a camera's projection.
@@ -97,7 +100,7 @@ pub enum Projection {
 /// [`Projection`]: enum.Projection.html
 #[derive(Clone, Debug, PartialEq)]
 pub struct Camera {
-    pub(crate) object: object::Base,
+    object: object::Base,
 
     /// Projection parameters of this camera.
     pub projection: Projection,
@@ -105,6 +108,13 @@ pub struct Camera {
 three_object!(Camera::object);
 
 impl Camera {
+    pub(crate) fn new(hub: &mut Hub, projection: Projection) -> Self {
+        Camera {
+            object: hub.spawn(SubNode::Empty),
+            projection,
+        }
+    }
+
     /// Computes the projection matrix representing the camera's projection.
     pub fn matrix(
         &self,

--- a/src/controls/orbit.rs
+++ b/src/controls/orbit.rs
@@ -94,7 +94,7 @@ impl Builder {
         let dir = (Point3::from(self.position) - Point3::from(self.target)).normalize();
         let up = Vector3::unit_z();
         let q = Quaternion::look_at(dir, up).invert();
-        let mut object = self.object.clone();
+        let object = self.object.clone();
         object.set_transform(self.position, q, 1.0);
 
         Orbit {

--- a/src/factory/load_gltf.rs
+++ b/src/factory/load_gltf.rs
@@ -246,14 +246,14 @@ impl super::Factory {
                 if has_entry {
                     let mesh = meshes.get(index).unwrap();
                     for primitive in mesh.iter() {
-                        let mut instance = self.mesh_instance(primitive);
-                        instance.set_parent(&item.group);
+                        let instance = self.mesh_instance(primitive);
+                        item.group.add(&instance);
                         instances.push(instance);
                     }
                 } else {
                     let mut primitives = self.load_gltf_mesh(&entry, buffers, base);
                     for primitive in &mut primitives {
-                        primitive.set_parent(&item.group);
+                        item.group.add(primitive);
                     }
                     meshes.insert(index, primitives);
                 }
@@ -265,27 +265,27 @@ impl super::Factory {
                         let center: mint::Point2<f32> = [0.0, 0.0].into();
                         let extent_y = values.ymag();
                         let range = values.znear() .. values.zfar();
-                        let mut camera = self.orthographic_camera(center, extent_y, range);
-                        camera.set_parent(&item.group);
+                        let camera = self.orthographic_camera(center, extent_y, range);
+                        item.group.add(&camera);
                         cameras.push(camera);
                     }
                     gltf::camera::Projection::Perspective(values) => {
                         let fov_y = values.yfov().to_degrees();
                         let near = values.znear();
-                        let mut camera = if let Some(far) = values.zfar() {
+                        let camera = if let Some(far) = values.zfar() {
                             self.perspective_camera(fov_y, near .. far)
                         } else {
                             self.perspective_camera(fov_y, near ..)
                         };
-                        camera.set_parent(&item.group);
+                        item.group.add(&camera);
                         cameras.push(camera);
                     }
                 }
             }
 
             for child in item.node.children() {
-                let mut child_group = self.group();
-                child_group.set_parent(&item.group);
+                let child_group = self.group();
+                item.group.add(&child_group);
                 stack.push(Item {
                     node: clone_child(&gltf, &child),
                     group: child_group,
@@ -386,11 +386,11 @@ impl super::Factory {
         let mut instances = Vec::new();
         let mut node_map = HashMap::new();
         let mut clips = Vec::new();
-        let group = self.group();
+        let mut group = self.group();
 
         if let Some(scene) = gltf.default_scene() {
             for root in scene.nodes() {
-                let mut node = self.load_gltf_node(
+                let node = self.load_gltf_node(
                     &gltf,
                     &root,
                     &buffers,
@@ -400,7 +400,7 @@ impl super::Factory {
                     &mut instances,
                     &mut node_map,
                 );
-                node.set_parent(&group);
+                group.add(&node);
             }
             clips = self.load_gltf_animations(&gltf, &node_map, &buffers);
         }

--- a/src/factory/load_gltf.rs
+++ b/src/factory/load_gltf.rs
@@ -234,7 +234,7 @@ impl super::Factory {
             },
         ];
 
-        while let Some(mut item) = stack.pop() {
+        while let Some(item) = stack.pop() {
             // TODO: Groups do not handle non-uniform scaling, so for now
             // we'll choose Y to be the scale factor in all directions.
             let (translation, rotation, scale) = item.node.transform().decomposed();
@@ -386,7 +386,7 @@ impl super::Factory {
         let mut instances = Vec::new();
         let mut node_map = HashMap::new();
         let mut clips = Vec::new();
-        let mut group = self.group();
+        let group = self.group();
 
         if let Some(scene) = gltf.default_scene() {
             for root in scene.nodes() {

--- a/src/factory/mod.rs
+++ b/src/factory/mod.rs
@@ -331,19 +331,17 @@ impl Factory {
     ) -> Mesh {
         let instances = self.create_instance_buffer();
         let mut hub = self.hub.lock().unwrap();
-        let material = match hub.get(&template).sub_node {
-            SubNode::Visual(ref mat, _) => mat.clone(),
-            _ => unreachable!(),
-        };
-        let gpu_data = match hub.get(&template).sub_node {
-            SubNode::Visual(_, ref gpu) => GpuData {
-                instances,
-                instance_cache_key: Some(InstanceCacheKey {
-                    material: material.clone(),
-                    geometry: gpu.vertices.clone(),
-                }),
-                ..gpu.clone()
-            },
+        let (material, gpu_data) = match hub[template].sub_node {
+            SubNode::Visual(ref mat, ref gpu) => {
+                (mat.clone(), GpuData {
+                    instances,
+                    instance_cache_key: Some(InstanceCacheKey {
+                        material: mat.clone(),
+                        geometry: gpu.vertices.clone(),
+                    }),
+                    ..gpu.clone()
+                })
+            }
             _ => unreachable!(),
         };
         Mesh {
@@ -359,9 +357,9 @@ impl Factory {
         material: M,
     ) -> Mesh {
         let instances = self.create_instance_buffer();
-        let mut hub = self.hub.lock().unwrap();
         let material = material.into();
-        let gpu_data = match hub.get(&template).sub_node {
+        let mut hub = self.hub.lock().unwrap();
+        let gpu_data = match hub[template].sub_node {
             SubNode::Visual(_, ref gpu) => GpuData {
                 instances,
                 instance_cache_key: Some(InstanceCacheKey {

--- a/src/factory/mod.rs
+++ b/src/factory/mod.rs
@@ -811,7 +811,7 @@ impl Factory {
         let mut indices = Vec::new();
 
         for object in obj.object_iter() {
-            let mut group = Group::new(&mut *hub);
+            let group = Group::new(&mut *hub);
             for gr in object.group_iter() {
                 let (mut num_normals, mut num_uvs) = (0, 0);
                 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,7 +340,7 @@ pub use material::Material;
 pub use mesh::{DynamicMesh, Mesh};
 
 #[doc(inline)]
-pub use node::{Node, Transform};
+pub use node::{Node, Transform, Local, World};
 
 #[doc(inline)]
 pub use object::{Group, Object};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,9 +70,8 @@
 //! #      color: 0xFFFF00,
 //! #      .. Default::default()
 //! # };
-//! # let mut mesh = window.factory.mesh(geometry, material);
-//! use three::Object;
-//! mesh.set_parent(&window.scene);
+//! # let mesh = window.factory.mesh(geometry, material);
+//! window.scene.add(&mesh);
 //! # }
 //! ```
 //!
@@ -110,8 +109,7 @@
 //! #         .. Default::default()
 //! #     };
 //! #     let mut mesh = window.factory.mesh(geometry, material);
-//! #     use three::Object;
-//! #     mesh.set_parent(&window.scene);
+//! #     window.scene.add(&mesh);
 //! let center = [0.0, 0.0];
 //! let yextent = 1.0;
 //! let zrange = -1.0 .. 1.0;
@@ -146,8 +144,8 @@
 //!         color: 0xFFFF00,
 //!         .. Default::default()
 //!     };
-//!     let mut mesh = window.factory.mesh(geometry, material);
-//!     mesh.set_parent(&window.scene);
+//!     let mesh = window.factory.mesh(geometry, material);
+//!     window.scene.add(&mesh);
 //!
 //!     let center = [0.0, 0.0];
 //!     let yextent = 1.0;
@@ -202,8 +200,8 @@
 //! fn main() {
 //! #    let mut window = three::Window::new("");
 //!     // Initialization code omitted.
-//!     let mut my_object = MyObject { group: window.factory.group() };
-//!     my_object.set_parent(&window.scene);
+//!     let my_object = MyObject { group: window.factory.group() };
+//!     window.scene.add(&my_object);
 //! }
 //! ```
 //!

--- a/src/object.rs
+++ b/src/object.rs
@@ -6,7 +6,7 @@ use std::sync::mpsc;
 
 use mint;
 
-use hub::{Message, Operation};
+use hub::{Hub, Message, Operation, SubNode};
 use node::NodePointer;
 
 
@@ -229,13 +229,16 @@ impl AsMut<Base> for Base {
 /// as with a single entity.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Group {
-    pub(crate) object: Base,
+    object: Base,
 }
 three_object!(Group::object);
 
 impl Group {
-    pub(crate) fn new(object: Base) -> Self {
-        Group { object }
+    pub(crate) fn new(hub: &mut Hub) -> Self {
+        let sub = SubNode::Group { first_child: None };
+        Group {
+            object: hub.spawn(sub),
+        }
     }
 
     /// Add new [`Base`](struct.Base.html) to the group.

--- a/src/object.rs
+++ b/src/object.rs
@@ -245,4 +245,15 @@ impl Group {
         let msg = Operation::AddChild(child.as_ref().node.clone());
         let _ = self.object.tx.send((self.object.node.downgrade(), msg));
     }
+
+    /// Removes a child [`Base`](struct.Base.html) from the group.
+    pub fn remove<P>(
+        &self,
+        child: P,
+    ) where
+        P: AsRef<Base>,
+    {
+        let msg = Operation::RemoveChild(child.as_ref().node.clone());
+        let _ = self.object.tx.send((self.object.node.downgrade(), msg));
+    }
 }

--- a/src/object.rs
+++ b/src/object.rs
@@ -40,15 +40,15 @@ pub trait Object: AsRef<Base> + AsMut<Base> {
 
     /// Invisible objects are not rendered by cameras.
     fn set_visible(
-        &mut self,
+        &self,
         visible: bool,
     ) {
-        self.as_mut().set_visible(visible)
+        self.as_ref().set_visible(visible)
     }
 
     /// Rotates object in the specific direction of `target`.
     fn look_at<E, T>(
-        &mut self,
+        &self,
         eye: E,
         target: T,
         up: Option<mint::Vector3<f32>>,
@@ -57,12 +57,12 @@ pub trait Object: AsRef<Base> + AsMut<Base> {
         E: Into<mint::Point3<f32>>,
         T: Into<mint::Point3<f32>>,
     {
-        self.as_mut().look_at(eye, target, up)
+        self.as_ref().look_at(eye, target, up)
     }
 
     /// Set both position, orientation and scale.
     fn set_transform<P, Q>(
-        &mut self,
+        &self,
         pos: P,
         rot: Q,
         scale: f32,
@@ -71,37 +71,37 @@ pub trait Object: AsRef<Base> + AsMut<Base> {
         P: Into<mint::Point3<f32>>,
         Q: Into<mint::Quaternion<f32>>,
     {
-        self.as_mut().set_transform(pos, rot, scale)
+        self.as_ref().set_transform(pos, rot, scale)
     }
 
     /// Set position.
     fn set_position<P>(
-        &mut self,
+        &self,
         pos: P,
     ) where
         Self: Sized,
         P: Into<mint::Point3<f32>>,
     {
-        self.as_mut().set_position(pos)
+        self.as_ref().set_position(pos)
     }
 
     /// Set orientation.
     fn set_orientation<Q>(
-        &mut self,
+        &self,
         rot: Q,
     ) where
         Self: Sized,
         Q: Into<mint::Quaternion<f32>>,
     {
-        self.as_mut().set_orientation(rot)
+        self.as_ref().set_orientation(rot)
     }
 
     /// Set scale.
     fn set_scale(
-        &mut self,
+        &self,
         scale: f32,
     ) {
-        self.as_mut().set_scale(scale)
+        self.as_ref().set_scale(scale)
     }
 }
 
@@ -137,7 +137,7 @@ impl fmt::Debug for Base {
 impl Base {
     /// Invisible objects are not rendered by cameras.
     pub fn set_visible(
-        &mut self,
+        &self,
         visible: bool,
     ) {
         let msg = Operation::SetVisible(visible);
@@ -146,7 +146,7 @@ impl Base {
 
     /// Rotates object in the specific direction of `target`.
     pub fn look_at<E, T>(
-        &mut self,
+        &self,
         eye: E,
         target: T,
         up: Option<mint::Vector3<f32>>,
@@ -169,7 +169,7 @@ impl Base {
 
     /// Set both position, orientation and scale.
     pub fn set_transform<P, Q>(
-        &mut self,
+        &self,
         pos: P,
         rot: Q,
         scale: f32,
@@ -183,7 +183,7 @@ impl Base {
 
     /// Set position.
     pub fn set_position<P>(
-        &mut self,
+        &self,
         pos: P,
     ) where
         P: Into<mint::Point3<f32>>,
@@ -194,7 +194,7 @@ impl Base {
 
     /// Set orientation.
     pub fn set_orientation<Q>(
-        &mut self,
+        &self,
         rot: Q,
     ) where
         Q: Into<mint::Quaternion<f32>>,
@@ -205,7 +205,7 @@ impl Base {
 
     /// Set scale.
     pub fn set_scale(
-        &mut self,
+        &self,
         scale: f32,
     ) {
         let msg = Operation::SetTransform(None, None, Some(scale));
@@ -215,12 +215,6 @@ impl Base {
 
 impl AsRef<Base> for Base {
     fn as_ref(&self) -> &Base {
-        self
-    }
-}
-
-impl AsMut<Base> for Base {
-    fn as_mut(&mut self) -> &mut Base {
         self
     }
 }
@@ -243,7 +237,7 @@ impl Group {
 
     /// Add new [`Base`](struct.Base.html) to the group.
     pub fn add<P>(
-        &mut self,
+        &self,
         child: P,
     ) where
         P: AsRef<Base>,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -726,7 +726,7 @@ impl Renderer {
         // prepare target and globals
         let (mx_inv_proj, mx_view, mx_vp) = {
             let p: [[f32; 4]; 4] = camera.matrix(self.aspect_ratio()).into();
-            let node = &hub.nodes[&camera.object.node];
+            let node = &hub[&camera];
             let world_transform = node.transform; //TODO!!!
             let mx_view = Matrix4::from(world_transform.inverse_transform().unwrap());
             let mx_vp = Matrix4::from(p) * mx_view;

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -10,6 +10,7 @@ use std::mem;
 use std::marker::PhantomData;
 use std::sync::MutexGuard;
 
+
 /// Background type.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Background {
@@ -166,7 +167,7 @@ impl<'a> SyncGuard<'a> {
     /// Panics if `scene` doesn't have this `object::Base`.
     ///
     /// [`Node`]: ../node/struct.Node.html
-    pub fn resolve<T: Object + 'a>(
+    pub fn resolve<T: 'a + Object>(
         &mut self,
         object: &T,
     ) -> node::Node<node::Local> {
@@ -180,13 +181,13 @@ impl<'a> SyncGuard<'a> {
     /// Panics if the doesn't have this `object::Base`.
     ///
     /// [`Node`]: ../node/struct.Node.html
-    pub fn resolve_world<T: Object + 'a>(
+    pub fn resolve_world<T: 'a + Object>(
         &mut self,
         object: &T,
     ) -> node::Node<node::World> {
         let internal = &self.hub[object] as *const _;
         let wn = self.hub
-            .walk(&self.scene.first_child)
+            .walk_all(&self.scene.first_child)
             .find(|wn| wn.node as *const _ == internal)
             .expect("Unable to find objects for world resolve!");
         node::Node {

--- a/src/text.rs
+++ b/src/text.rs
@@ -13,6 +13,7 @@ use color::Color;
 use hub::Operation as HubOperation;
 use render::{BackendCommandBuffer, BackendFactory, BackendResources, ColorFormat, DepthFormat};
 
+#[derive(Debug)]
 pub(crate) enum Operation {
     Text(String),
     Font(Font),

--- a/src/text.rs
+++ b/src/text.rs
@@ -36,7 +36,7 @@ pub enum Align {
     /// Leftmost & rightmost characters are equidistant to the render position.
     /// Bounds start from the render position and advance equally left & right.
     Center,
-    /// Rightmost character is immetiately to the left of the render position.
+    /// Rightmost character is immediately to the left of the render position.
     /// Bounds start from the render position and advance leftwards.
     Right,
 }


### PR DESCRIPTION
Fixes #44

Core of the change is switching relationships from "child->parent" to "parent->first_child->sibling", which gives us the following benefits:
  - clean children lifetimes, as expected by users
    - no need to store all the meshes returned by gltf/obj loaders: perhaps, we can follow-up with a PR that allows querying meshes by name from their parents, so that we don't even return all the meshes directly in the loader API
  - nice `Group::add(&something)`, like Three-js does
  - make `Scene` truly unique and node-less
  - no need for unique scene IDs
    ~~- technically, objects can now be present in multiple scenes at once~~
  - immutable node data upon traversal (!):
    - we just compute the world visibility/transform on the fly
    - thus, no need for a separate `update_transforms` step
    - uses pretty iterators ;)
    - as a downside, not as straightforward to reflect the world info to the user (see TODO)

Has other changes making things nicer:
  - refactored frame render code
  - no `&mut self` on objects
  - idiomatic hub indexing
  - safer group/camera/text/audio spawning (internal)
  - more robust message handling (panic on unprocessed/unexpected messages)
  - can debug print the `Operation`

TODO:
- [x] check/fix docs
- [x] compute world transform/visibility for the user if needed (is it needed?)
- [x] provide API to detach from parent
- [x] reviews!
- [x] profile the cost of recomputing the world transforms
  
  
  