### PR TITLE
Derive Debug and Clone impls for Gltf

### DIFF
--- a/src/factory/mod.rs
+++ b/src/factory/mod.rs
@@ -84,6 +84,7 @@ pub struct Factory {
 ///
 /// [`Factory::load_gltf`]: struct.Factory.html#method.load_gltf
 #[cfg(feature = "gltf-loader")]
+#[derive(Debug, Clone)]
 pub struct Gltf {
     /// Imported camera views.
     pub cameras: Vec<Camera>,


### PR DESCRIPTION
I noticed that these were missing, and they seemed reasonable to add. Let me know if there's any reason we wouldn't want `Gltf` to be `Debug` or `Clone`.