### PR TITLE
Export MouseButton

### DIFF
--- a/src/controls/mod.rs
+++ b/src/controls/mod.rs
@@ -28,7 +28,7 @@ pub mod orbit;
 
 pub use self::first_person::FirstPerson;
 pub use self::orbit::Orbit;
-pub use input::{axis, Button, Delta, Hit, HitCount, Input, Timer, AXIS_DOWN_UP, AXIS_LEFT_RIGHT, KEY_ESCAPE, KEY_SPACE, MOUSE_LEFT, MOUSE_RIGHT};
+pub use input::{axis, Button, Delta, Hit, HitCount, Input, MouseButton, Timer, AXIS_DOWN_UP, AXIS_LEFT_RIGHT, KEY_ESCAPE, KEY_SPACE, MOUSE_LEFT, MOUSE_RIGHT};
 
 /// Virtual key code.
 pub use input::Key;

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,5 +1,5 @@
-use glutin::{ElementState, MouseButton, MouseScrollDelta};
-pub use glutin::VirtualKeyCode as Key;
+use glutin::{ElementState, MouseScrollDelta};
+pub use glutin::{MouseButton, VirtualKeyCode as Key};
 use mint;
 
 use std::collections::HashSet;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,7 +324,7 @@ pub use color::Color;
 pub use controls::{AXIS_DOWN_UP, AXIS_LEFT_RIGHT, KEY_ESCAPE, KEY_SPACE, MOUSE_LEFT, MOUSE_RIGHT};
 
 #[doc(inline)]
-pub use controls::{Button, Input, Timer};
+pub use controls::{Button, MouseButton, Input, Timer};
 
 #[doc(inline)]
 pub use factory::Factory;


### PR DESCRIPTION
`MouseButton` wasn't being re-exported, which meant that using it required pulling in glutin or winit as a dependency. I've re-exported it from three so it can be used more easily.