### PR TITLE
Don't count keys hits while key is pressed

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -188,8 +188,10 @@ impl Input {
     ) {
         match state {
             ElementState::Pressed => {
-                self.state.keys_pressed.insert(key);
-                self.delta.keys_hit.push(key);
+                if !self.state.keys_pressed.contains(&key) {
+                    self.state.keys_pressed.insert(key);
+                    self.delta.keys_hit.push(key);
+                }
             }
             ElementState::Released => {
                 self.state.keys_pressed.remove(&key);


### PR DESCRIPTION
closes #187 
The behavior of `sprite` and `lights` examples is changed slightly (now you can't hold the key), but I think now it's more logical