### PR TITLE
[WIP] Rework glTF loading API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
 Cargo.lock
+
+# Configuration file for editors using the RLS.
+rls.toml

--- a/examples/gltf-morph-targets.rs
+++ b/examples/gltf-morph-targets.rs
@@ -12,12 +12,12 @@ fn main() {
     let default = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/AnimatedMorphCube/AnimatedMorphCube.gltf");
     let path = std::env::args().nth(1).unwrap_or(default.into());
     let gltf = window.factory.load_gltf(&path);
-    window.scene.add(&gltf);
+    // window.scene.add(&gltf);
 
     let mut mixer = three::animation::Mixer::new();
-    for clip in gltf.clips {
-        mixer.action(clip);
-    }
+    // for clip in gltf.clips {
+    //     mixer.action(clip);
+    // }
 
     let camera = window.factory.perspective_camera(60.0, 0.1 .. 20.0);
     camera.set_position([0.0, 1.0, 5.0]);

--- a/examples/gltf-morph-targets.rs
+++ b/examples/gltf-morph-targets.rs
@@ -9,15 +9,21 @@ fn main() {
     window.scene.add(&light);
     window.scene.background = three::Background::Color(0xC6F0FF);
 
+    // Load the glTF file.
     let default = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/AnimatedMorphCube/AnimatedMorphCube.gltf");
     let path = std::env::args().nth(1).unwrap_or(default.into());
     let gltf = window.factory.load_gltf(&path);
-    // window.scene.add(&gltf);
 
+    // Instantiate the contents of the file.
+    let instance = window.factory.instantiate_gltf_scene(&gltf, 0);
+    window.scene.add(&instance);
+
+    // Instantiate all of the animations in the glTF file and start playing them.
     let mut mixer = three::animation::Mixer::new();
-    // for clip in gltf.clips {
-    //     mixer.action(clip);
-    // }
+    for anim_def in &gltf.animations {
+        let clip = window.factory.instantiate_gltf_animation(&instance, anim_def).unwrap();
+        mixer.action(clip);
+    }
 
     let camera = window.factory.perspective_camera(60.0, 0.1 .. 20.0);
     camera.set_position([0.0, 1.0, 5.0]);

--- a/examples/gltf-morph-targets.rs
+++ b/examples/gltf-morph-targets.rs
@@ -26,11 +26,10 @@ fn main() {
     }
 
     let camera = window.factory.perspective_camera(60.0, 0.1 .. 20.0);
-    camera.set_position([0.0, 1.0, 5.0]);
 
     let mut controls = three::controls::Orbit::builder(&camera)
-        .position([-0.08, -0.05, 0.075])
-        .target([0.0, 0.0, 0.01])
+        .position([-3.0, 3.0, -3.0])
+        .up([0.0, 1.0, 0.0])
         .build();
 
     while window.update() && !window.input.hit(three::KEY_ESCAPE) {

--- a/examples/gltf-node-animation.rs
+++ b/examples/gltf-node-animation.rs
@@ -12,12 +12,12 @@ fn main() {
     let default = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/BoxAnimated/BoxAnimated.gltf");
     let path = std::env::args().nth(1).unwrap_or(default.into());
     let gltf = window.factory.load_gltf(&path);
-    window.scene.add(&gltf);
+    // window.scene.add(&gltf);
 
     let mut mixer = three::animation::Mixer::new();
-    for clip in gltf.clips {
-        mixer.action(clip);
-    }
+    // for clip in gltf.clips {
+    //     mixer.action(clip);
+    // }
 
     let camera = window.factory.perspective_camera(60.0, 0.1 .. 100.0);
     window.scene.add(&camera);

--- a/examples/gltf-node-animation.rs
+++ b/examples/gltf-node-animation.rs
@@ -9,15 +9,21 @@ fn main() {
     window.scene.add(&light);
     window.scene.background = three::Background::Color(0xC6F0FF);
 
+    // Load the glTF file.
     let default = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/BoxAnimated/BoxAnimated.gltf");
     let path = std::env::args().nth(1).unwrap_or(default.into());
     let gltf = window.factory.load_gltf(&path);
-    // window.scene.add(&gltf);
 
+    // Instantiate the contents of the file.
+    let instance = window.factory.instantiate_gltf_scene(&gltf, 0);
+    window.scene.add(&instance);
+
+    // Instantiate all of the animations in the glTF file and start playing them.
     let mut mixer = three::animation::Mixer::new();
-    // for clip in gltf.clips {
-    //     mixer.action(clip);
-    // }
+    for anim_def in &gltf.animations {
+        let clip = window.factory.instantiate_gltf_animation(&instance, anim_def).unwrap();
+        mixer.action(clip);
+    }
 
     let camera = window.factory.perspective_camera(60.0, 0.1 .. 100.0);
     window.scene.add(&camera);

--- a/examples/gltf-pbr-shader.rs
+++ b/examples/gltf-pbr-shader.rs
@@ -16,13 +16,21 @@ fn main() {
     let instance = win.factory.instantiate_gltf_scene(&gltf, 0);
     win.scene.add(&instance);
 
-    let cam = /* if gltf.cameras.len() > 0 {
-        gltf.cameras.swap_remove(0)
-    } else */{
+    // If there is already a camera in the instantiated glTF scene, use that one.
+    let mut cam = None;
+    for node in instance.nodes.values() {
+        if let Some(ref camera) = node.camera {
+            cam = Some(camera.clone());
+            break;
+        }
+    }
+
+    // If we didn't find a camera in the glTF scene, create a default one to use.
+    let cam = cam.unwrap_or_else(|| {
         let default = win.factory.perspective_camera(60.0, 0.001 .. 100.0);
         win.scene.add(&default);
         default
-    };
+    });
 
     let skybox_path = three::CubeMapPath {
         front: "test_data/skybox/posz.jpg",

--- a/examples/gltf-pbr-shader.rs
+++ b/examples/gltf-pbr-shader.rs
@@ -12,12 +12,13 @@ fn main() {
     let default = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/Lantern/Lantern.gltf");
     let path = std::env::args().nth(1).unwrap_or(default.into());
     println!("Loading {:?} (this may take a while)", path);
-    let mut gltf = win.factory.load_gltf(&path);
-    win.scene.add(&gltf);
+    let gltf = win.factory.load_gltf(&path);
+    let instance = win.factory.instantiate_gltf_scene(&gltf, 0);
+    win.scene.add(&instance);
 
-    let cam = if gltf.cameras.len() > 0 {
+    let cam = /* if gltf.cameras.len() > 0 {
         gltf.cameras.swap_remove(0)
-    } else {
+    } else */{
         let default = win.factory.perspective_camera(60.0, 0.001 .. 100.0);
         win.scene.add(&default);
         default

--- a/examples/gltf-vertex-skinning.rs
+++ b/examples/gltf-vertex-skinning.rs
@@ -12,12 +12,14 @@ fn main() {
     let default = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/BrainStem/BrainStem.gltf");
     let path = std::env::args().nth(1).unwrap_or(default.into());
     let gltf = window.factory.load_gltf(&path);
-    // window.scene.add(&gltf);
+    let instance = window.factory.instantiate_gltf_scene(&gltf, 0);
+    window.scene.add(&instance);
 
     let mut mixer = three::animation::Mixer::new();
-    // for clip in gltf.clips {
-    //     mixer.action(clip);
-    // }
+    for anim_def in &gltf.animations {
+        let clip = window.factory.instantiate_gltf_animation(&instance, anim_def);
+        mixer.action(clip);
+    }
 
     let camera = window.factory.perspective_camera(45.0, 0.1 .. 100.0);
     window.scene.add(&camera);

--- a/examples/gltf-vertex-skinning.rs
+++ b/examples/gltf-vertex-skinning.rs
@@ -15,9 +15,10 @@ fn main() {
     let instance = window.factory.instantiate_gltf_scene(&gltf, 0);
     window.scene.add(&instance);
 
+    // Instantiate all of the animations in the glTF file and start playing them.
     let mut mixer = three::animation::Mixer::new();
     for anim_def in &gltf.animations {
-        let clip = window.factory.instantiate_gltf_animation(&instance, anim_def);
+        let clip = window.factory.instantiate_gltf_animation(&instance, anim_def).unwrap();
         mixer.action(clip);
     }
 

--- a/examples/gltf-vertex-skinning.rs
+++ b/examples/gltf-vertex-skinning.rs
@@ -12,12 +12,12 @@ fn main() {
     let default = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/BrainStem/BrainStem.gltf");
     let path = std::env::args().nth(1).unwrap_or(default.into());
     let gltf = window.factory.load_gltf(&path);
-    window.scene.add(&gltf);
+    // window.scene.add(&gltf);
 
     let mut mixer = three::animation::Mixer::new();
-    for clip in gltf.clips {
-        mixer.action(clip);
-    }
+    // for clip in gltf.clips {
+    //     mixer.action(clip);
+    // }
 
     let camera = window.factory.perspective_camera(45.0, 0.1 .. 100.0);
     window.scene.add(&camera);

--- a/examples/gltf-vertex-skinning.rs
+++ b/examples/gltf-vertex-skinning.rs
@@ -9,9 +9,12 @@ fn main() {
     window.scene.add(&light);
     window.scene.background = three::Background::Color(0xC6F0FF);
 
+    // Load the glTF file.
     let default = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/BrainStem/BrainStem.gltf");
     let path = std::env::args().nth(1).unwrap_or(default.into());
     let gltf = window.factory.load_gltf(&path);
+
+    // Instantiate the contents of the file.
     let instance = window.factory.instantiate_gltf_scene(&gltf, 0);
     window.scene.add(&instance);
 

--- a/examples/gltf-vertex-skinning.rs
+++ b/examples/gltf-vertex-skinning.rs
@@ -29,8 +29,9 @@ fn main() {
     window.scene.add(&camera);
 
     let mut controls = three::controls::Orbit::builder(&camera)
-        .position([0.0, -3.0, 3.0])
-        .target([0.0, 0.0, 1.0])
+        .position([0.0, 3.0, 3.0])
+        .target([0.0, 1.0, 0.0])
+        .up([0.0, 1.0, 0.0])
         .build();
 
     while window.update() && !window.input.hit(three::KEY_ESCAPE) {

--- a/src/controls/orbit.rs
+++ b/src/controls/orbit.rs
@@ -26,6 +26,7 @@ pub struct Orbit {
 pub struct Builder {
     object: object::Base,
     position: mint::Point3<f32>,
+    up: mint::Vector3<f32>,
     target: mint::Point3<f32>,
     button: Button,
     speed: f32,
@@ -37,6 +38,7 @@ impl Builder {
         Builder {
             object: object.upcast(),
             position: [0.0, 0.0, 0.0].into(),
+            up: [0.0, 0.0, 1.0].into(),
             target: [0.0, 0.0, 0.0].into(),
             button: MOUSE_LEFT,
             speed: 1.0,
@@ -54,6 +56,20 @@ impl Builder {
         P: Into<mint::Point3<f32>>,
     {
         self.position = position.into();
+        self
+    }
+
+    /// Sets the initial up direction.
+    ///
+    /// Defaults to the unit z axis.
+    pub fn up<P>(
+        &mut self,
+        up: P,
+    ) -> &mut Self
+    where
+        P: Into<mint::Vector3<f32>>
+    {
+        self.up = up.into();
         self
     }
 
@@ -92,8 +108,8 @@ impl Builder {
     /// Finalize builder and create new `OrbitControls`.
     pub fn build(&mut self) -> Orbit {
         let dir = (Point3::from(self.position) - Point3::from(self.target)).normalize();
-        let up = Vector3::unit_z();
-        let q = Quaternion::look_at(dir, up).invert();
+        let up = self.up;
+        let q = Quaternion::look_at(dir, up.into()).invert();
         let object = self.object.clone();
         object.set_transform(self.position, q, 1.0);
 

--- a/src/factory/load_gltf.rs
+++ b/src/factory/load_gltf.rs
@@ -27,32 +27,54 @@ use geometry::{Geometry, Shape};
 use object::{self, Object};
 use super::Factory;
 
-/// The contents of a scene defined in a glTF file, fully insantiated and ready to be added to
-/// a scene and rendered.
+/// A glTF scene that has been instantiated and can be added to a [`Scene`].
 ///
-/// # Notes
+/// Created by instantiating a scene defined in a [`GltfDefinitions`] with
+/// [`Factory::instantiate_gltf_scene`]. A `GltfScene` can be added to a [`Scene`] with
+/// [`Scene::add`].
 ///
-/// The various contents
+/// # Examples
+///
+/// ```no_run
+/// # let mut window = three::Window::new("three-rs");
+/// let definitions = window.factory.load_gltf("my_data.gltf");
+///
+/// let gltf_scene = window.factory.instantiate_gltf_scene(&definitions, 0);
+/// window.scene.add(&gltf_scene);
+/// ```
+///
+/// [`Scene`]: struct.Scene.html
+/// [`Scene::add`]: struct.Scene.html#method.add
+/// [`GltfDefinitions`]: struct.GltfDefinitions.html
+/// [`Factory::instantiate_gltf_scene`]: struct.Factory.html#method.instantiate_gltf_scene
 #[derive(Debug, Clone)]
 pub struct GltfScene {
     /// A group containing all of the root nodes of the scene.
     ///
     /// While the glTF format allows scenes to have an arbitrary number of root nodes, all scene
     /// roots are added to a single root group to make it easier to manipulate the scene as a
-    /// whole. See `roots` for the full list of root nodes for the scene.
+    /// whole. See [`roots`] for the full list of root nodes for the scene.
+    ///
+    /// [`roots`]: #structfield.roots
     pub group: object::Group,
 
     /// The indices of the root nodes of the scene.
     ///
-    /// Each index corresponds to a node in `nodes`.
+    /// Each index corresponds to a node in [`nodes`].
+    ///
+    /// [`nodes`]: #structfield.nodes
     pub roots: Vec<usize>,
 
     /// The nodes that are part of the scene.
     ///
     /// Node instances are stored in a [`HashMap`] where the key is the node's index in the source
     /// [`GltfDefinitions::nodes`]. Note that a [`HashMap`] is used instead of a [`Vec`] because
-    /// the not all nodes in the source file are guaranteed to be used in the scene, and so node
+    /// not all nodes in the source file are guaranteed to be used in the scene, and so node
     /// indices in the scene instance may not be contiguous.
+    ///
+    /// [`HashMap`]: https://doc.rust-lang.org/stable/std/collections/struct.HashMap.html
+    /// [`Vec`]: https://doc.rust-lang.org/stable/std/vec/struct.Vec.html
+    /// [`GltfDefinitions::nodes`]: struct.GltfDefinitions.html#structfield.nodes
     pub nodes: HashMap<usize, GltfNode>,
 }
 
@@ -156,9 +178,13 @@ pub struct GltfDefinitions {
 
 /// A template for a glTF mesh instance.
 ///
-/// Note that a glTF mesh doesn't map directly to three's concept of a [`Mesh`] (see
-/// [`GltfPrimitiveDefinition`] for a more direct analogy). Rather, `GltfMeshDefinition` can be instantated
-/// into a [`Group`] with one or more [`Mesh`] instances added to the group.
+/// Note that a glTF mesh doesn't map directly to three's [`Mesh`] type (see
+/// [`GltfPrimitiveDefinition`] for a more direct analogy). Rather, `GltfMeshDefinition` can
+/// be instantated into a [`Group`] with one or more [`Mesh`] instances added to the group.
+///
+/// [`Mesh`]: struct.Mesh.html
+/// [`GltfPrimitiveDefinition`]: struct.GltfPrimitiveDefinition.html
+/// [`Group`]: struct.Group.html
 #[derive(Debug, Clone)]
 pub struct GltfMeshDefinition {
     /// The name of the mesh template.

--- a/src/factory/load_gltf.rs
+++ b/src/factory/load_gltf.rs
@@ -22,7 +22,7 @@ use skeleton::Skeleton;
 use std::path::{Path, PathBuf};
 use vec_map::VecMap;
 
-use animation::Clip;
+use animation::{Clip, Track};
 use {Group, Material, Mesh, Texture};
 use geometry::{Geometry, Shape};
 use object;
@@ -104,6 +104,9 @@ pub struct GltfDefinitions {
 
     /// The skinned skeltons loaded from the glTF file.
     pub skins: Vec<GltfSkinDefinition>,
+
+    /// The animation clips loaded from the glTF file.
+    pub animations: Vec<GltfAnimationDefinition>,
 }
 
 /// A template for a glTF mesh instance.
@@ -219,6 +222,22 @@ pub struct GltfBoneDefinition {
     ///
     /// This index corresponds to a node in the `nodes` list of the parent [`GltfDefinitions`].
     pub joint: usize,
+}
+
+/// The definition for an animation in a glTF file.
+///
+/// When instantiated, this corresponds to a [`Clip`].
+#[derive(Debug, Clone)]
+pub struct GltfAnimationDefinition {
+    /// The name of the animation.
+    pub name: Option<String>,
+
+    /// The tracks making up the animation.
+    ///
+    /// Each track is composed of a [`Track`] containing the data for the track, and an index
+    /// of the node that the track targets. The node is an index into the `nodes` list of the
+    /// parent [`GltfDefinitions`].
+    pub tracks: Vec<(Track, usize)>,
 }
 
 fn build_scene_hierarchy(

--- a/src/factory/load_gltf.rs
+++ b/src/factory/load_gltf.rs
@@ -883,4 +883,25 @@ impl super::Factory {
             roots,
         }
     }
+
+    /// Instantiate an animation from a glTF file and apply it to the contents of a glTF scene.
+    pub fn instantiate_gltf_animation(
+        &mut self,
+        scene: &GltfScene,
+        anim_def: &GltfAnimationDefinition,
+    ) -> Clip {
+        // Apply each track in the animation definition to its target node in the scene.
+        let mut tracks = Vec::with_capacity(anim_def.tracks.len());
+        for &(ref track, target_index) in &anim_def.tracks {
+            // TODO: What do if the target isn't in the scene?
+            let target = scene.nodes[&target_index].upcast();
+
+            tracks.push((track.clone(), target));
+        }
+
+        Clip {
+            name: anim_def.name.clone(),
+            tracks,
+        }
+    }
 }

--- a/src/factory/load_gltf.rs
+++ b/src/factory/load_gltf.rs
@@ -56,6 +56,29 @@ pub struct GltfScene {
     pub nodes: HashMap<usize, GltfNode>,
 }
 
+impl GltfScene {
+    /// Finds the first node in the scene with the specified name, using a [`GltfDefinitions`]
+    /// to lookup the name for each node.
+    ///
+    /// Name matching is case-sensitive. Returns the first node with a matching name, otherwise
+    /// returns `None`.
+    pub fn find_node_by_name(
+        &self,
+        name: &str,
+        definitions: &GltfDefinitions,
+    ) -> Option<&GltfNode> {
+        for (index, node) in &self.nodes {
+            if let Some(node_def) = definitions.nodes.get(*index) {
+                if node_def.name.as_ref().map(|node_name| node_name == name).unwrap_or(false) {
+                    return Some(node);
+                }
+            }
+        }
+
+        None
+    }
+}
+
 impl AsRef<object::Base> for GltfScene {
     fn as_ref(&self) -> &object::Base {
         self.group.as_ref()

--- a/src/factory/load_gltf.rs
+++ b/src/factory/load_gltf.rs
@@ -99,8 +99,11 @@ pub struct GltfDefinitions {
     /// The scene nodes loaded from the glTF file.
     pub nodes: Vec<GltfNodeDefinition>,
 
-    /// The scenes described from the glTF file.
+    /// The scenes described in the glTF file.
     pub scenes: Vec<GltfSceneDefinition>,
+
+    /// The skinned skeltons loaded from the glTF file.
+    pub skins: Vec<GltfSkinDefinition>,
 }
 
 /// A template for a glTF mesh instance.
@@ -193,6 +196,29 @@ pub struct GltfSceneDefinition {
     ///
     /// These indices correspond to elements in the
     pub roots: Vec<usize>,
+}
+
+/// The definition for a skeleton used for vertex skinning in a glTF file.
+///
+/// When instantiated, this corresponds to a [`Skeleton`].
+#[derive(Debug, Clone)]
+pub struct GltfSkinDefinition {
+    /// The bones composing the skeleton.
+    pub bones: Vec<GltfBoneDefinition>,
+}
+
+/// The definition for a bone in a [`GltfSkinDefinition`].
+///
+/// When instantiated, this corresponds to a [`Bone`].
+#[derive(Debug, Clone)]
+pub struct GltfBoneDefinition {
+    /// The inverse bind matrix used to transform the mesh for this bone's joint.
+    pub inverse_bind_matrix: mint::ColumnMatrix4<f32>,
+
+    /// The index of the node that acts as the joint for this bone.
+    ///
+    /// This index corresponds to a node in the `nodes` list of the parent [`GltfDefinitions`].
+    pub joint: usize,
 }
 
 fn build_scene_hierarchy(

--- a/src/factory/mod.rs
+++ b/src/factory/mod.rs
@@ -16,11 +16,7 @@ use image;
 use itertools::Either;
 use mint;
 use obj;
-#[cfg(feature = "gltf-loader")]
-use vec_map::VecMap;
 
-#[cfg(feature = "gltf-loader")]
-use animation::Clip;
 use audio;
 use camera::{Camera, Projection, ZRange};
 use color::{BLACK, Color};
@@ -40,6 +36,9 @@ use sprite::Sprite;
 use skeleton::{Bone, Skeleton};
 use text::{Font, Text, TextData};
 use texture::{CubeMap, CubeMapPath, FilterMethod, Sampler, Texture, WrapMode};
+
+#[cfg(feature = "gltf-loader")]
+pub use self::load_gltf::*;
 
 const TANGENT_X: [I8Norm; 4] = [I8Norm(1), I8Norm(0), I8Norm(0), I8Norm(1)];
 const NORMAL_Z: [I8Norm; 4] = [I8Norm(0), I8Norm(0), I8Norm(1), I8Norm(0)];
@@ -78,60 +77,6 @@ pub struct Factory {
     texture_cache: HashMap<PathBuf, Texture<[f32; 4]>>,
     default_sampler: gfx::handle::Sampler<BackendResources>,
 }
-
-/// Loaded glTF 2.0 returned by [`Factory::load_gltf`].
-///
-/// [`Factory::load_gltf`]: struct.Factory.html#method.load_gltf
-#[cfg(feature = "gltf-loader")]
-#[derive(Debug, Clone)]
-pub struct Gltf {
-    /// Imported camera views.
-    pub cameras: Vec<Camera>,
-
-    /// Imported animation clips.
-    pub clips: Vec<Clip>,
-
-    /// The node heirarchy of the default scene.
-    ///
-    /// If the `glTF` contained no default scene then this
-    /// container will be empty.
-    pub heirarchy: VecMap<object::Group>,
-
-    /// Imported mesh instances.
-    ///
-    /// ### Notes
-    ///
-    /// * Must be kept alive in order to be displayed.
-    pub instances: Vec<Mesh>,
-
-    /// Imported mesh materials.
-    pub materials: Vec<Material>,
-
-    /// Imported mesh templates.
-    pub meshes: VecMap<Vec<Mesh>>,
-
-    /// The root node of the default scene.
-    ///
-    /// If the `glTF` contained no default scene then this group
-    /// will have no children.
-    pub root: object::Group,
-
-    /// Imported skeletons.
-    pub skeletons: Vec<Skeleton>,
-
-    /// Imported textures.
-    pub textures: Vec<Texture<[f32; 4]>>,
-}
-
-#[cfg(feature = "gltf-loader")]
-impl AsRef<object::Base> for Gltf {
-    fn as_ref(&self) -> &object::Base {
-        self.root.as_ref()
-    }
-}
-
-#[cfg(feature = "gltf-loader")]
-impl object::Object for Gltf {}
 
 fn f2i(x: f32) -> I8Norm {
     I8Norm(cmp::min(cmp::max((x * 127.0) as isize, -128), 127) as i8)

--- a/src/factory/mod.rs
+++ b/src/factory/mod.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "gltf-loader")]
-mod load_gltf;
+pub(crate) mod load_gltf;
 
 use std::{cmp, fs, io, iter, ops};
 use std::borrow::Cow;
@@ -36,9 +36,6 @@ use sprite::Sprite;
 use skeleton::{Bone, Skeleton};
 use text::{Font, Text, TextData};
 use texture::{CubeMap, CubeMapPath, FilterMethod, Sampler, Texture, WrapMode};
-
-#[cfg(feature = "gltf-loader")]
-pub use self::load_gltf::*;
 
 const TANGENT_X: [I8Norm; 4] = [I8Norm(1), I8Norm(0), I8Norm(0), I8Norm(1)];
 const NORMAL_Z: [I8Norm; 4] = [I8Norm(0), I8Norm(0), I8Norm(1), I8Norm(0)];
@@ -156,6 +153,19 @@ impl Factory {
         let data = hub::SkeletonData { bones, gpu_buffer, gpu_buffer_view };
         let object = self.hub.lock().unwrap().spawn_skeleton(data);
         Skeleton { object }
+    }
+
+    /// Create a new camera using the provided projection.
+    ///
+    /// This allows you to create a camera from a predefined projection, which is useful if you
+    /// e.g. load projection data from a file and don't necessarily know ahead of time what type
+    /// of projection the camera uses. If you're manually creating a camera, you should use
+    /// [`perspective_camera`] or [`orthographic_camera`].
+    pub fn camera<P: Into<Projection>>(&mut self, projection: P) -> Camera {
+        Camera::new(
+            &mut *self.hub.lock().unwrap(),
+            projection.into(),
+        )
     }
 
     /// Create new [Orthographic] Camera.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,7 +328,7 @@ pub use factory::Factory;
 
 #[cfg(feature = "gltf-loader")]
 #[doc(inline)]
-pub use factory::Gltf;
+pub use factory::load_gltf::*;
 
 #[doc(inline)]
 pub use geometry::{Geometry, Joints, Shape};


### PR DESCRIPTION
> NOTE: This PR is not yet ready to merge, but I would like to get feedback on the overall direction of this approach while I'm finishing the final details.

This PR proposes a major reworking of the API for loading and instantiating glTF assets. There are two primary goals for these changes:

* Expose more information from the source glTF file (e.g. the names of nodes, access to all scenes defined in the file, etc.).
* Make it possible to instantiate the contents of a glTF file multiple times without having to load the file from disk every time.

To accomplish this, I have split glTF loading into two parts:

1. Load the data and definitions from the glTF file into a `GltfDefinitions` object.
2. Use the `GltfDefinitions` to instantiate objects that can be added to the scene.

With this new API, loading a glTF files and adding its contents to a scene would go as follows:

```
// Load the definitions from the glTF file.
let definitions = window.factory.load_gltf(&path);

// Instantiate the first scene defined.
let instance = window.factory.instantiate_gltf_scene(&definitions, 0);
window.scene.add(&instance);
```

This only takes one more step than it did before, but it allows users to easily instantiate the contents of the file multiple times.

# Drawbacks

The current API isn't ideal from an ergonomics perspective. `GltfDefinitions` is setup to match the structure of the glTF file, which means objects reference each other by index. Even when you instantiate a scene, the nodes in a `GltfScene` are still setup to reference each other by index. I think this can be fixed using custom iterators and accessor types that abstract away the underlying indexing operations, similar to how the types in the `gltf` crate are implemented.

Currently I don't include node names in an instantiated `GltfScene`, which means you still need to use the `GltfDefinitions` to look up nodes by name. This could be improved by including names in `GltfScene`, at the cost of copying the names every time the user instantiates a scene.

Animations aren't instantiated automatically. To instantiate an animation, you have to specify a `GltfScene` that it should be applied to, and creating the animation can fail if it references a node that isn't present in the `GltfScene`. As far as I could tell, there was no information in the glTF spec that states which animations are part of which scenes, otherwise I would instantiate animations automatically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/three-rs/three/197)
<!-- Reviewable:end -->
