### PR TITLE
[WIP] Hierarchy templating API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
 Cargo.lock
+
+# Configuration file for editors using the RLS.
+rls.toml

--- a/examples/gltf-morph-targets.rs
+++ b/examples/gltf-morph-targets.rs
@@ -12,12 +12,12 @@ fn main() {
     let default = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/AnimatedMorphCube/AnimatedMorphCube.gltf");
     let path = std::env::args().nth(1).unwrap_or(default.into());
     let gltf = window.factory.load_gltf(&path);
-    window.scene.add(&gltf);
+    // window.scene.add(&gltf);
 
     let mut mixer = three::animation::Mixer::new();
-    for clip in gltf.clips {
-        mixer.action(clip);
-    }
+    // for clip in gltf.clips {
+    //     mixer.action(clip);
+    // }
 
     let camera = window.factory.perspective_camera(60.0, 0.1 .. 20.0);
     camera.set_position([0.0, 1.0, 5.0]);

--- a/examples/gltf-morph-targets.rs
+++ b/examples/gltf-morph-targets.rs
@@ -9,15 +9,21 @@ fn main() {
     window.scene.add(&light);
     window.scene.background = three::Background::Color(0xC6F0FF);
 
+    // Load the glTF file.
     let default = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/AnimatedMorphCube/AnimatedMorphCube.gltf");
     let path = std::env::args().nth(1).unwrap_or(default.into());
     let gltf = window.factory.load_gltf(&path);
-    // window.scene.add(&gltf);
 
+    // Instantiate the contents of the file.
+    let instance = window.factory.instantiate_gltf_scene(&gltf, 0);
+    window.scene.add(&instance);
+
+    // Instantiate all of the animations in the glTF file and start playing them.
     let mut mixer = three::animation::Mixer::new();
-    // for clip in gltf.clips {
-    //     mixer.action(clip);
-    // }
+    for anim_def in &gltf.animations {
+        let clip = window.factory.instantiate_gltf_animation(&instance, anim_def).unwrap();
+        mixer.action(clip);
+    }
 
     let camera = window.factory.perspective_camera(60.0, 0.1 .. 20.0);
     camera.set_position([0.0, 1.0, 5.0]);

--- a/examples/gltf-morph-targets.rs
+++ b/examples/gltf-morph-targets.rs
@@ -26,11 +26,10 @@ fn main() {
     }
 
     let camera = window.factory.perspective_camera(60.0, 0.1 .. 20.0);
-    camera.set_position([0.0, 1.0, 5.0]);
 
     let mut controls = three::controls::Orbit::builder(&camera)
-        .position([-0.08, -0.05, 0.075])
-        .target([0.0, 0.0, 0.01])
+        .position([-3.0, 3.0, -3.0])
+        .up([0.0, 1.0, 0.0])
         .build();
 
     while window.update() && !window.input.hit(three::KEY_ESCAPE) {

--- a/examples/gltf-morph-targets.rs
+++ b/examples/gltf-morph-targets.rs
@@ -12,16 +12,12 @@ fn main() {
     // Load the glTF file.
     let default = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/AnimatedMorphCube/AnimatedMorphCube.gltf");
     let path = std::env::args().nth(1).unwrap_or(default.into());
-    let gltf = window.factory.load_gltf(&path);
-
-    // Instantiate the contents of the file.
-    let instance = window.factory.instantiate_gltf_scene(&gltf, 0);
-    window.scene.add(&instance);
+    let hierarchy = window.factory.load_gltf(&path).pop().unwrap();
+    window.scene.add(&hierarchy);
 
     // Instantiate all of the animations in the glTF file and start playing them.
     let mut mixer = three::animation::Mixer::new();
-    for anim_def in &gltf.animations {
-        let clip = window.factory.instantiate_gltf_animation(&instance, anim_def).unwrap();
+    for clip in hierarchy.animations {
         mixer.action(clip);
     }
 

--- a/examples/gltf-node-animation.rs
+++ b/examples/gltf-node-animation.rs
@@ -12,16 +12,12 @@ fn main() {
     // Load the glTF file.
     let default = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/BoxAnimated/BoxAnimated.gltf");
     let path = std::env::args().nth(1).unwrap_or(default.into());
-    let gltf = window.factory.load_gltf(&path);
-
-    // Instantiate the contents of the file.
-    let instance = window.factory.instantiate_gltf_scene(&gltf, 0);
-    window.scene.add(&instance);
+    let hierarchy = window.factory.load_gltf(&path).pop().unwrap();
+    window.scene.add(&hierarchy);
 
     // Instantiate all of the animations in the glTF file and start playing them.
     let mut mixer = three::animation::Mixer::new();
-    for anim_def in &gltf.animations {
-        let clip = window.factory.instantiate_gltf_animation(&instance, anim_def).unwrap();
+    for clip in hierarchy.animations {
         mixer.action(clip);
     }
 

--- a/examples/gltf-node-animation.rs
+++ b/examples/gltf-node-animation.rs
@@ -12,12 +12,12 @@ fn main() {
     let default = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/BoxAnimated/BoxAnimated.gltf");
     let path = std::env::args().nth(1).unwrap_or(default.into());
     let gltf = window.factory.load_gltf(&path);
-    window.scene.add(&gltf);
+    // window.scene.add(&gltf);
 
     let mut mixer = three::animation::Mixer::new();
-    for clip in gltf.clips {
-        mixer.action(clip);
-    }
+    // for clip in gltf.clips {
+    //     mixer.action(clip);
+    // }
 
     let camera = window.factory.perspective_camera(60.0, 0.1 .. 100.0);
     window.scene.add(&camera);

--- a/examples/gltf-node-animation.rs
+++ b/examples/gltf-node-animation.rs
@@ -9,15 +9,21 @@ fn main() {
     window.scene.add(&light);
     window.scene.background = three::Background::Color(0xC6F0FF);
 
+    // Load the glTF file.
     let default = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/BoxAnimated/BoxAnimated.gltf");
     let path = std::env::args().nth(1).unwrap_or(default.into());
     let gltf = window.factory.load_gltf(&path);
-    // window.scene.add(&gltf);
 
+    // Instantiate the contents of the file.
+    let instance = window.factory.instantiate_gltf_scene(&gltf, 0);
+    window.scene.add(&instance);
+
+    // Instantiate all of the animations in the glTF file and start playing them.
     let mut mixer = three::animation::Mixer::new();
-    // for clip in gltf.clips {
-    //     mixer.action(clip);
-    // }
+    for anim_def in &gltf.animations {
+        let clip = window.factory.instantiate_gltf_animation(&instance, anim_def).unwrap();
+        mixer.action(clip);
+    }
 
     let camera = window.factory.perspective_camera(60.0, 0.1 .. 100.0);
     window.scene.add(&camera);

--- a/examples/gltf-pbr-shader.rs
+++ b/examples/gltf-pbr-shader.rs
@@ -12,13 +12,12 @@ fn main() {
     let default = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/Lantern/Lantern.gltf");
     let path = std::env::args().nth(1).unwrap_or(default.into());
     println!("Loading {:?} (this may take a while)", path);
-    let gltf = win.factory.load_gltf(&path);
-    let instance = win.factory.instantiate_gltf_scene(&gltf, 0);
-    win.scene.add(&instance);
+    let gltf = win.factory.load_gltf(&path).pop().unwrap();
+    win.scene.add(&gltf);
 
     // If there is already a camera in the instantiated glTF scene, use that one.
     let mut cam = None;
-    for node in instance.nodes.values() {
+    for node in gltf.nodes.values() {
         if let Some(ref camera) = node.camera {
             cam = Some(camera.clone());
             break;

--- a/examples/gltf-pbr-shader.rs
+++ b/examples/gltf-pbr-shader.rs
@@ -16,13 +16,21 @@ fn main() {
     let instance = win.factory.instantiate_gltf_scene(&gltf, 0);
     win.scene.add(&instance);
 
-    let cam = /* if gltf.cameras.len() > 0 {
-        gltf.cameras.swap_remove(0)
-    } else */{
+    // If there is already a camera in the instantiated glTF scene, use that one.
+    let mut cam = None;
+    for node in instance.nodes.values() {
+        if let Some(ref camera) = node.camera {
+            cam = Some(camera.clone());
+            break;
+        }
+    }
+
+    // If we didn't find a camera in the glTF scene, create a default one to use.
+    let cam = cam.unwrap_or_else(|| {
         let default = win.factory.perspective_camera(60.0, 0.001 .. 100.0);
         win.scene.add(&default);
         default
-    };
+    });
 
     let skybox_path = three::CubeMapPath {
         front: "test_data/skybox/posz.jpg",

--- a/examples/gltf-pbr-shader.rs
+++ b/examples/gltf-pbr-shader.rs
@@ -12,12 +12,13 @@ fn main() {
     let default = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/Lantern/Lantern.gltf");
     let path = std::env::args().nth(1).unwrap_or(default.into());
     println!("Loading {:?} (this may take a while)", path);
-    let mut gltf = win.factory.load_gltf(&path);
-    win.scene.add(&gltf);
+    let gltf = win.factory.load_gltf(&path);
+    let instance = win.factory.instantiate_gltf_scene(&gltf, 0);
+    win.scene.add(&instance);
 
-    let cam = if gltf.cameras.len() > 0 {
+    let cam = /* if gltf.cameras.len() > 0 {
         gltf.cameras.swap_remove(0)
-    } else {
+    } else */{
         let default = win.factory.perspective_camera(60.0, 0.001 .. 100.0);
         win.scene.add(&default);
         default

--- a/examples/gltf-vertex-skinning.rs
+++ b/examples/gltf-vertex-skinning.rs
@@ -12,12 +12,14 @@ fn main() {
     let default = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/BrainStem/BrainStem.gltf");
     let path = std::env::args().nth(1).unwrap_or(default.into());
     let gltf = window.factory.load_gltf(&path);
-    // window.scene.add(&gltf);
+    let instance = window.factory.instantiate_gltf_scene(&gltf, 0);
+    window.scene.add(&instance);
 
     let mut mixer = three::animation::Mixer::new();
-    // for clip in gltf.clips {
-    //     mixer.action(clip);
-    // }
+    for anim_def in &gltf.animations {
+        let clip = window.factory.instantiate_gltf_animation(&instance, anim_def);
+        mixer.action(clip);
+    }
 
     let camera = window.factory.perspective_camera(45.0, 0.1 .. 100.0);
     window.scene.add(&camera);

--- a/examples/gltf-vertex-skinning.rs
+++ b/examples/gltf-vertex-skinning.rs
@@ -15,9 +15,10 @@ fn main() {
     let instance = window.factory.instantiate_gltf_scene(&gltf, 0);
     window.scene.add(&instance);
 
+    // Instantiate all of the animations in the glTF file and start playing them.
     let mut mixer = three::animation::Mixer::new();
     for anim_def in &gltf.animations {
-        let clip = window.factory.instantiate_gltf_animation(&instance, anim_def);
+        let clip = window.factory.instantiate_gltf_animation(&instance, anim_def).unwrap();
         mixer.action(clip);
     }
 

--- a/examples/gltf-vertex-skinning.rs
+++ b/examples/gltf-vertex-skinning.rs
@@ -12,12 +12,12 @@ fn main() {
     let default = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/BrainStem/BrainStem.gltf");
     let path = std::env::args().nth(1).unwrap_or(default.into());
     let gltf = window.factory.load_gltf(&path);
-    window.scene.add(&gltf);
+    // window.scene.add(&gltf);
 
     let mut mixer = three::animation::Mixer::new();
-    for clip in gltf.clips {
-        mixer.action(clip);
-    }
+    // for clip in gltf.clips {
+    //     mixer.action(clip);
+    // }
 
     let camera = window.factory.perspective_camera(45.0, 0.1 .. 100.0);
     window.scene.add(&camera);

--- a/examples/gltf-vertex-skinning.rs
+++ b/examples/gltf-vertex-skinning.rs
@@ -9,9 +9,12 @@ fn main() {
     window.scene.add(&light);
     window.scene.background = three::Background::Color(0xC6F0FF);
 
+    // Load the glTF file.
     let default = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/BrainStem/BrainStem.gltf");
     let path = std::env::args().nth(1).unwrap_or(default.into());
     let gltf = window.factory.load_gltf(&path);
+
+    // Instantiate the contents of the file.
     let instance = window.factory.instantiate_gltf_scene(&gltf, 0);
     window.scene.add(&instance);
 

--- a/examples/gltf-vertex-skinning.rs
+++ b/examples/gltf-vertex-skinning.rs
@@ -29,8 +29,9 @@ fn main() {
     window.scene.add(&camera);
 
     let mut controls = three::controls::Orbit::builder(&camera)
-        .position([0.0, -3.0, 3.0])
-        .target([0.0, 0.0, 1.0])
+        .position([0.0, 3.0, 3.0])
+        .target([0.0, 1.0, 0.0])
+        .up([0.0, 1.0, 0.0])
         .build();
 
     while window.update() && !window.input.hit(three::KEY_ESCAPE) {

--- a/examples/gltf-vertex-skinning.rs
+++ b/examples/gltf-vertex-skinning.rs
@@ -12,16 +12,12 @@ fn main() {
     // Load the glTF file.
     let default = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/BrainStem/BrainStem.gltf");
     let path = std::env::args().nth(1).unwrap_or(default.into());
-    let gltf = window.factory.load_gltf(&path);
-
-    // Instantiate the contents of the file.
-    let instance = window.factory.instantiate_gltf_scene(&gltf, 0);
-    window.scene.add(&instance);
+    let hierarchy = window.factory.load_gltf(&path).pop().unwrap();
+    window.scene.add(&hierarchy);
 
     // Instantiate all of the animations in the glTF file and start playing them.
     let mut mixer = three::animation::Mixer::new();
-    for anim_def in &gltf.animations {
-        let clip = window.factory.instantiate_gltf_animation(&instance, anim_def).unwrap();
+    for clip in hierarchy.animations {
         mixer.action(clip);
     }
 

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -110,7 +110,7 @@ three_object!(Camera::object);
 impl Camera {
     pub(crate) fn new(hub: &mut Hub, projection: Projection) -> Self {
         Camera {
-            object: hub.spawn(SubNode::Empty),
+            object: hub.spawn(SubNode::Empty.into()),
             projection,
         }
     }

--- a/src/controls/orbit.rs
+++ b/src/controls/orbit.rs
@@ -26,6 +26,7 @@ pub struct Orbit {
 pub struct Builder {
     object: object::Base,
     position: mint::Point3<f32>,
+    up: mint::Vector3<f32>,
     target: mint::Point3<f32>,
     button: Button,
     speed: f32,
@@ -37,6 +38,7 @@ impl Builder {
         Builder {
             object: object.upcast(),
             position: [0.0, 0.0, 0.0].into(),
+            up: [0.0, 0.0, 1.0].into(),
             target: [0.0, 0.0, 0.0].into(),
             button: MOUSE_LEFT,
             speed: 1.0,
@@ -54,6 +56,20 @@ impl Builder {
         P: Into<mint::Point3<f32>>,
     {
         self.position = position.into();
+        self
+    }
+
+    /// Sets the initial up direction.
+    ///
+    /// Defaults to the unit z axis.
+    pub fn up<P>(
+        &mut self,
+        up: P,
+    ) -> &mut Self
+    where
+        P: Into<mint::Vector3<f32>>
+    {
+        self.up = up.into();
         self
     }
 
@@ -92,8 +108,8 @@ impl Builder {
     /// Finalize builder and create new `OrbitControls`.
     pub fn build(&mut self) -> Orbit {
         let dir = (Point3::from(self.position) - Point3::from(self.target)).normalize();
-        let up = Vector3::unit_z();
-        let q = Quaternion::look_at(dir, up).invert();
+        let up = self.up;
+        let q = Quaternion::look_at(dir, up.into()).invert();
         let object = self.object.clone();
         object.set_transform(self.position, q, 1.0);
 

--- a/src/factory/load_gltf.rs
+++ b/src/factory/load_gltf.rs
@@ -27,32 +27,54 @@ use geometry::{Geometry, Shape};
 use object::{self, Object};
 use super::Factory;
 
-/// The contents of a scene defined in a glTF file, fully insantiated and ready to be added to
-/// a scene and rendered.
+/// A glTF scene that has been instantiated and can be added to a [`Scene`].
 ///
-/// # Notes
+/// Created by instantiating a scene defined in a [`GltfDefinitions`] with
+/// [`Factory::instantiate_gltf_scene`]. A `GltfScene` can be added to a [`Scene`] with
+/// [`Scene::add`].
 ///
-/// The various contents
+/// # Examples
+///
+/// ```no_run
+/// # let mut window = three::Window::new("three-rs");
+/// let definitions = window.factory.load_gltf("my_data.gltf");
+///
+/// let gltf_scene = window.factory.instantiate_gltf_scene(&definitions, 0);
+/// window.scene.add(&gltf_scene);
+/// ```
+///
+/// [`Scene`]: struct.Scene.html
+/// [`Scene::add`]: struct.Scene.html#method.add
+/// [`GltfDefinitions`]: struct.GltfDefinitions.html
+/// [`Factory::instantiate_gltf_scene`]: struct.Factory.html#method.instantiate_gltf_scene
 #[derive(Debug, Clone)]
 pub struct GltfScene {
     /// A group containing all of the root nodes of the scene.
     ///
     /// While the glTF format allows scenes to have an arbitrary number of root nodes, all scene
     /// roots are added to a single root group to make it easier to manipulate the scene as a
-    /// whole. See `roots` for the full list of root nodes for the scene.
+    /// whole. See [`roots`] for the full list of root nodes for the scene.
+    ///
+    /// [`roots`]: #structfield.roots
     pub group: object::Group,
 
     /// The indices of the root nodes of the scene.
     ///
-    /// Each index corresponds to a node in `nodes`.
+    /// Each index corresponds to a node in [`nodes`].
+    ///
+    /// [`nodes`]: #structfield.nodes
     pub roots: Vec<usize>,
 
     /// The nodes that are part of the scene.
     ///
     /// Node instances are stored in a [`HashMap`] where the key is the node's index in the source
     /// [`GltfDefinitions::nodes`]. Note that a [`HashMap`] is used instead of a [`Vec`] because
-    /// the not all nodes in the source file are guaranteed to be used in the scene, and so node
+    /// not all nodes in the source file are guaranteed to be used in the scene, and so node
     /// indices in the scene instance may not be contiguous.
+    ///
+    /// [`HashMap`]: https://doc.rust-lang.org/stable/std/collections/struct.HashMap.html
+    /// [`Vec`]: https://doc.rust-lang.org/stable/std/vec/struct.Vec.html
+    /// [`GltfDefinitions::nodes`]: struct.GltfDefinitions.html#structfield.nodes
     pub nodes: HashMap<usize, GltfNode>,
 }
 
@@ -156,9 +178,13 @@ pub struct GltfDefinitions {
 
 /// A template for a glTF mesh instance.
 ///
-/// Note that a glTF mesh doesn't map directly to three's concept of a [`Mesh`] (see
-/// [`GltfPrimitiveDefinition`] for a more direct analogy). Rather, `GltfMeshDefinition` can be instantated
-/// into a [`Group`] with one or more [`Mesh`] instances added to the group.
+/// Note that a glTF mesh doesn't map directly to three's [`Mesh`] type (see
+/// [`GltfPrimitiveDefinition`] for a more direct analogy). Rather, `GltfMeshDefinition` can
+/// be instantated into a [`Group`] with one or more [`Mesh`] instances added to the group.
+///
+/// [`Mesh`]: struct.Mesh.html
+/// [`GltfPrimitiveDefinition`]: struct.GltfPrimitiveDefinition.html
+/// [`Group`]: struct.Group.html
 #[derive(Debug, Clone)]
 pub struct GltfMeshDefinition {
     /// The name of the mesh template.

--- a/src/factory/load_gltf.rs
+++ b/src/factory/load_gltf.rs
@@ -460,6 +460,7 @@ fn instantiate_node_hierarchy<'a>(
 
     // Bind the skeleton to the node's meshes.
     if let Some(ref skeleton) = skeleton {
+        group.add(skeleton);
         for mesh in &mut meshes {
             mesh.set_skeleton(skeleton.clone());
         }

--- a/src/factory/load_gltf.rs
+++ b/src/factory/load_gltf.rs
@@ -319,7 +319,7 @@ fn load_skin<'a>(
 
 fn load_animation<'a>(
     animation: gltf::Animation<'a>,
-    nodes: HashMap<usize, HierarchyNode>,
+    nodes: &HashMap<usize, HierarchyNode>,
     buffers: &gltf_importer::Buffers,
 ) -> Clip {
     use gltf::animation::InterpolationAlgorithm::*;
@@ -473,6 +473,7 @@ fn instantiate_node_hierarchy<'a>(
 fn load_scene<'a>(
     factory: &mut Factory,
     scene: gltf::Scene<'a>,
+    animations: gltf::gltf::Animations<'a>,
     buffers: &gltf_importer::Buffers,
     textures: &[Texture<[f32; 4]>],
 ) -> Hierarchy {
@@ -487,11 +488,15 @@ fn load_scene<'a>(
         .map(|node| node.index())
         .collect();
 
+    let animations = animations
+        .map(|anim| load_animation(anim, &nodes, buffers))
+        .collect();
+
     Hierarchy {
         group,
         roots,
         nodes,
-        animations: Vec::new(),
+        animations,
     }
 }
 
@@ -516,7 +521,7 @@ impl super::Factory {
 
         gltf
             .scenes()
-            .map(|scene| load_scene(self, scene, &buffers, &textures))
+            .map(|scene| load_scene(self, scene, gltf.animations(), &buffers, &textures))
             .collect()
     }
 }

--- a/src/factory/load_gltf.rs
+++ b/src/factory/load_gltf.rs
@@ -22,7 +22,7 @@ use skeleton::Skeleton;
 use std::path::{Path, PathBuf};
 use vec_map::VecMap;
 
-use animation::Clip;
+use animation::{Clip, Track};
 use {Group, Material, Mesh, Texture};
 use geometry::{Geometry, Shape};
 use object;
@@ -104,6 +104,9 @@ pub struct GltfDefinitions {
 
     /// The skinned skeltons loaded from the glTF file.
     pub skins: Vec<GltfSkinDefinition>,
+
+    /// The animation clips loaded from the glTF file.
+    pub animations: Vec<GltfAnimationDefinition>,
 }
 
 /// A template for a glTF mesh instance.
@@ -219,6 +222,22 @@ pub struct GltfBoneDefinition {
     ///
     /// This index corresponds to a node in the `nodes` list of the parent [`GltfDefinitions`].
     pub joint: usize,
+}
+
+/// The definition for an animation in a glTF file.
+///
+/// When instantiated, this corresponds to a [`Clip`].
+#[derive(Debug, Clone)]
+pub struct GltfAnimationDefinition {
+    /// The name of the animation.
+    pub name: Option<String>,
+
+    /// The tracks making up the animation.
+    ///
+    /// Each track is composed of a [`Track`] containing the data for the track, and an index
+    /// of the node that the track targets. The node is an index into the `nodes` list of the
+    /// parent [`GltfDefinitions`].
+    pub tracks: Vec<(Track, usize)>,
 }
 
 fn build_scene_hierarchy(

--- a/src/factory/load_gltf.rs
+++ b/src/factory/load_gltf.rs
@@ -431,7 +431,7 @@ fn instantiate_node_hierarchy<'a>(
     group.set_scale(scale);
     group.set_orientation(rotation);
 
-    let meshes = node
+    let mut meshes = node
         .mesh()
         .map(|mesh| load_mesh(factory, mesh, buffers, textures))
         .unwrap_or_default();
@@ -457,6 +457,13 @@ fn instantiate_node_hierarchy<'a>(
     let skeleton = node
         .skin()
         .map(|skin| load_skin(factory, skin, buffers, nodes));
+
+    // Bind the skeleton to the node's meshes.
+    if let Some(ref skeleton) = skeleton {
+        for mesh in &mut meshes {
+            mesh.set_skeleton(skeleton.clone());
+        }
+    }
 
     let name = node.name().map(Into::into);
 

--- a/src/factory/load_gltf.rs
+++ b/src/factory/load_gltf.rs
@@ -883,4 +883,25 @@ impl super::Factory {
             roots,
         }
     }
+
+    /// Instantiate an animation from a glTF file and apply it to the contents of a glTF scene.
+    pub fn instantiate_gltf_animation(
+        &mut self,
+        scene: &GltfScene,
+        anim_def: &GltfAnimationDefinition,
+    ) -> Clip {
+        // Apply each track in the animation definition to its target node in the scene.
+        let mut tracks = Vec::with_capacity(anim_def.tracks.len());
+        for &(ref track, target_index) in &anim_def.tracks {
+            // TODO: What do if the target isn't in the scene?
+            let target = scene.nodes[&target_index].upcast();
+
+            tracks.push((track.clone(), target));
+        }
+
+        Clip {
+            name: anim_def.name.clone(),
+            tracks,
+        }
+    }
 }

--- a/src/factory/load_gltf.rs
+++ b/src/factory/load_gltf.rs
@@ -56,6 +56,29 @@ pub struct GltfScene {
     pub nodes: HashMap<usize, GltfNode>,
 }
 
+impl GltfScene {
+    /// Finds the first node in the scene with the specified name, using a [`GltfDefinitions`]
+    /// to lookup the name for each node.
+    ///
+    /// Name matching is case-sensitive. Returns the first node with a matching name, otherwise
+    /// returns `None`.
+    pub fn find_node_by_name(
+        &self,
+        name: &str,
+        definitions: &GltfDefinitions,
+    ) -> Option<&GltfNode> {
+        for (index, node) in &self.nodes {
+            if let Some(node_def) = definitions.nodes.get(*index) {
+                if node_def.name.as_ref().map(|node_name| node_name == name).unwrap_or(false) {
+                    return Some(node);
+                }
+            }
+        }
+
+        None
+    }
+}
+
 impl AsRef<object::Base> for GltfScene {
     fn as_ref(&self) -> &object::Base {
         self.group.as_ref()

--- a/src/factory/load_gltf.rs
+++ b/src/factory/load_gltf.rs
@@ -16,307 +16,16 @@ use mint;
 use std::{fs, io};
 use std::collections::HashMap;
 
-use camera::{Camera, Orthographic, Perspective, Projection};
+use camera::{Orthographic, Perspective, Projection};
 use gltf_utils::AccessorIter;
-use skeleton::Skeleton;
 use std::path::{Path, PathBuf};
 
-use animation::{Clip, Track};
-use {Group, Material, Mesh, Texture};
+use animation::Clip;
+use {Group, Material, Texture};
 use geometry::{Geometry, Shape};
-use object::{self, Object};
+use object::Object;
 use super::Factory;
-
-/// A glTF scene that has been instantiated and can be added to a [`Scene`].
-///
-/// Created by instantiating a scene defined in a [`GltfDefinitions`] with
-/// [`Factory::instantiate_gltf_scene`]. A `GltfScene` can be added to a [`Scene`] with
-/// [`Scene::add`].
-///
-/// # Examples
-///
-/// ```no_run
-/// # let mut window = three::Window::new("three-rs");
-/// let definitions = window.factory.load_gltf("my_data.gltf");
-///
-/// let gltf_scene = window.factory.instantiate_gltf_scene(&definitions, 0);
-/// window.scene.add(&gltf_scene);
-/// ```
-///
-/// [`Scene`]: struct.Scene.html
-/// [`Scene::add`]: struct.Scene.html#method.add
-/// [`GltfDefinitions`]: struct.GltfDefinitions.html
-/// [`Factory::instantiate_gltf_scene`]: struct.Factory.html#method.instantiate_gltf_scene
-#[derive(Debug, Clone)]
-pub struct GltfScene {
-    /// A group containing all of the root nodes of the scene.
-    ///
-    /// While the glTF format allows scenes to have an arbitrary number of root nodes, all scene
-    /// roots are added to a single root group to make it easier to manipulate the scene as a
-    /// whole. See [`roots`] for the full list of root nodes for the scene.
-    ///
-    /// [`roots`]: #structfield.roots
-    pub group: object::Group,
-
-    /// The indices of the root nodes of the scene.
-    ///
-    /// Each index corresponds to a node in [`nodes`].
-    ///
-    /// [`nodes`]: #structfield.nodes
-    pub roots: Vec<usize>,
-
-    /// The nodes that are part of the scene.
-    ///
-    /// Node instances are stored in a [`HashMap`] where the key is the node's index in the source
-    /// [`GltfDefinitions::nodes`]. Note that a [`HashMap`] is used instead of a [`Vec`] because
-    /// not all nodes in the source file are guaranteed to be used in the scene, and so node
-    /// indices in the scene instance may not be contiguous.
-    ///
-    /// [`HashMap`]: https://doc.rust-lang.org/stable/std/collections/struct.HashMap.html
-    /// [`Vec`]: https://doc.rust-lang.org/stable/std/vec/struct.Vec.html
-    /// [`GltfDefinitions::nodes`]: struct.GltfDefinitions.html#structfield.nodes
-    pub nodes: HashMap<usize, GltfNode>,
-}
-
-impl GltfScene {
-    /// Finds the first node in the scene with the specified name, using a [`GltfDefinitions`]
-    /// to lookup the name for each node.
-    ///
-    /// Name matching is case-sensitive. Returns the first node with a matching name, otherwise
-    /// returns `None`.
-    pub fn find_node_by_name(
-        &self,
-        name: &str,
-        definitions: &GltfDefinitions,
-    ) -> Option<&GltfNode> {
-        for (index, node) in &self.nodes {
-            if let Some(node_def) = definitions.nodes.get(*index) {
-                if node_def.name.as_ref().map(|node_name| node_name == name).unwrap_or(false) {
-                    return Some(node);
-                }
-            }
-        }
-
-        None
-    }
-}
-
-impl AsRef<object::Base> for GltfScene {
-    fn as_ref(&self) -> &object::Base {
-        self.group.as_ref()
-    }
-}
-
-impl object::Object for GltfScene {}
-
-/// A node in a scene from a glTF file that has been instantiated.
-#[derive(Debug, Clone)]
-pub struct GltfNode {
-    /// The group that represents this node.
-    pub group: Group,
-
-    /// The meshes associated with this node.
-    pub meshes: Vec<Mesh>,
-
-    /// The skeleton associated with this node.
-    ///
-    /// If `skeleton` has a value, then there will be at least one mesh in `meshes`.
-    pub skeleton: Option<Skeleton>,
-
-    /// The camera associated with this node.
-    pub camera: Option<Camera>,
-
-    /// The indices of the children of this node.
-    pub children: Vec<usize>,
-}
-
-impl AsRef<object::Base> for GltfNode {
-    fn as_ref(&self) -> &object::Base {
-        self.group.as_ref()
-    }
-}
-
-impl object::Object for GltfNode {}
-
-/// Raw data loaded from a glTF file with [`Factory::load_gltf`].
-///
-/// This is the raw data used as a template to instantiate three objects in the scene. Entire
-/// glTF scenes can be instantiated using [`Factory::instantiate_gltf_scene`].
-///
-/// [`Factory::load_gltf`]: struct.Factory.html#method.load_gltf
-#[derive(Debug, Clone)]
-pub struct GltfDefinitions {
-    /// The materials loaded from the glTF file.
-    pub materials: Vec<Material>,
-
-    /// The camera projections defined in the glTF file.
-    pub cameras: Vec<Projection>,
-
-    /// The meshes loaded from the glTF file.
-    pub meshes: Vec<GltfMeshDefinition>,
-
-    /// The scene nodes loaded from the glTF file.
-    pub nodes: Vec<GltfNodeDefinition>,
-
-    /// The scenes described in the glTF file.
-    pub scenes: Vec<GltfSceneDefinition>,
-
-    /// The index of the default scene, if specified by the glTF file.
-    ///
-    /// The index corresponds to an element in `scenes`.
-    pub default_scene: Option<usize>,
-
-    /// The skinned skeltons loaded from the glTF file.
-    pub skins: Vec<GltfSkinDefinition>,
-
-    /// The animation clips loaded from the glTF file.
-    pub animations: Vec<GltfAnimationDefinition>,
-
-    /// Imported textures.
-    pub textures: Vec<Texture<[f32; 4]>>,
-}
-
-/// A template for a glTF mesh instance.
-///
-/// Note that a glTF mesh doesn't map directly to three's [`Mesh`] type (see
-/// [`GltfPrimitiveDefinition`] for a more direct analogy). Rather, `GltfMeshDefinition` can
-/// be instantated into a [`Group`] with one or more [`Mesh`] instances added to the group.
-///
-/// [`Mesh`]: struct.Mesh.html
-/// [`GltfPrimitiveDefinition`]: struct.GltfPrimitiveDefinition.html
-/// [`Group`]: struct.Group.html
-#[derive(Debug, Clone)]
-pub struct GltfMeshDefinition {
-    /// The name of the mesh template.
-    pub name: Option<String>,
-
-    /// The primitives included in the mesh template.
-    ///
-    /// When the mesh template is instantiated, each primitive is instantiated as a [`Mesh`].
-    pub primitives: Vec<GltfPrimitiveDefinition>,
-}
-
-/// A template for a glTF mesh primitive.
-///
-/// A `GltfPrimitiveDefinition` can be converted directly into a [`Mesh`] using [`Factory::mesh`]. Note that
-/// to do this, the material must first be retrieved by index from the parent [`GltfDefinitions`].
-#[derive(Debug, Clone)]
-pub struct GltfPrimitiveDefinition {
-    /// The geometric data described by this primitive.
-    pub geometry: Geometry,
-
-    /// The index of the material associated with this mesh primitive, if any.
-    ///
-    /// The index can be used to lookup the material data from the `materials` map of the parent
-    /// [`GltfDefinitions`].
-    ///
-    /// If no material is specified, then the glTF default material (an unlit, flat black material)
-    /// will be used when instantiating the primitive.
-    pub material: Option<usize>,
-}
-
-/// The definition of a node used in a glTF file.
-///
-/// Nodes are composed to create a graph of elements in a glTF scene.
-#[derive(Debug, Clone)]
-pub struct GltfNodeDefinition {
-    /// The name of the node.
-    pub name: Option<String>,
-
-    /// The index of the mesh associated with this node, if any.
-    ///
-    /// The index can be used to lookup the associated mesh definition in the `meshes` map of the
-    /// parent [`GltfDefinitions`].
-    pub mesh: Option<usize>,
-
-    /// The index of the camera associated with this node, if any.
-    ///
-    /// The index can be used to lookup the associated camera projection in the `cameras` map of
-    /// the parent [`GltfDefinitions`].
-    pub camera: Option<usize>,
-
-    /// The index of the skin attached to this node, if any.
-    ///
-    /// The index corresponds to a skin in the `skins` list of the parent [`GltfDefinitions`].
-    ///
-    /// Note that if `skin` has a value, then `mesh` will also have a value.
-    pub skin: Option<usize>,
-
-    /// The indices of this node's children. A node may have zero or more children.
-    ///
-    /// Each index corresponds to a node in the `nodes` map of the parent [`GltfDefinitions`].
-    pub children: Vec<usize>,
-
-    /// The node's local translation.
-    ///
-    /// This translation is relative to its parent node when instantiated.
-    pub translation: mint::Point3<f32>,
-
-    /// The node's local orientation.
-    ///
-    /// This rotation is relative to its parent node when instantiated.
-    pub rotation: mint::Quaternion<f32>,
-
-    /// The node's local scale.
-    ///
-    /// This scale is relative to its parent node when instantiated.
-    pub scale: f32,
-}
-
-/// The definition of a scene from a glTF file.
-///
-/// A glTF scene is a hierarchy of nodes, begining with one or more root nodes. Note that glTF
-/// scenes are *not* the same as three [`Scene`]s, and must be explicity added to a [`Scene`]
-/// when instantiated.
-#[derive(Debug, Clone)]
-pub struct GltfSceneDefinition {
-    /// The name of the scene.
-    pub name: Option<String>,
-
-    /// The indices of the root nodes of the scene.
-    ///
-    /// These indices correspond to elements in the
-    pub roots: Vec<usize>,
-}
-
-/// The definition for a skeleton used for vertex skinning in a glTF file.
-///
-/// When instantiated, this corresponds to a [`Skeleton`].
-#[derive(Debug, Clone)]
-pub struct GltfSkinDefinition {
-    /// The bones composing the skeleton.
-    pub bones: Vec<GltfBoneDefinition>,
-}
-
-/// The definition for a bone in a [`GltfSkinDefinition`].
-///
-/// When instantiated, this corresponds to a [`Bone`].
-#[derive(Debug, Clone)]
-pub struct GltfBoneDefinition {
-    /// The inverse bind matrix used to transform the mesh for this bone's joint.
-    pub inverse_bind_matrix: mint::ColumnMatrix4<f32>,
-
-    /// The index of the node that acts as the joint for this bone.
-    ///
-    /// This index corresponds to a node in the `nodes` list of the parent [`GltfDefinitions`].
-    pub joint: usize,
-}
-
-/// The definition for an animation in a glTF file.
-///
-/// When instantiated, this corresponds to a [`Clip`].
-#[derive(Debug, Clone)]
-pub struct GltfAnimationDefinition {
-    /// The name of the animation.
-    pub name: Option<String>,
-
-    /// The tracks making up the animation.
-    ///
-    /// Each track is composed of a [`Track`] containing the data for the track, and an index
-    /// of the node that the track targets. The node is an index into the `nodes` list of the
-    /// parent [`GltfDefinitions`].
-    pub tracks: Vec<(Track, usize)>,
-}
+use template::*;
 
 fn load_camera<'a>(
     entry: gltf::Camera<'a>,
@@ -695,16 +404,16 @@ fn load_animation<'a>(
     }
 }
 
-fn load_scene<'a>(scene: gltf::Scene<'a>) -> GltfSceneDefinition {
+fn load_scene<'a>(scene: gltf::Scene<'a>) -> HierarchyDefinition {
     let roots = scene.nodes().map(|node| node.index()).collect();
 
-    GltfSceneDefinition {
+    HierarchyDefinition {
         name: scene.name().map(Into::into),
         roots,
     }
 }
 
-fn load_node<'a>(node: gltf::Node<'a>) -> GltfNodeDefinition {
+fn load_node<'a>(node: gltf::Node<'a>) -> NodeDefinition {
     let name = node.name().map(Into::into);
 
     let mesh = node.mesh().map(|mesh| mesh.index());
@@ -719,7 +428,7 @@ fn load_node<'a>(node: gltf::Node<'a>) -> GltfNodeDefinition {
     // scale factor in all directions.
     let scale = scale[1];
 
-    GltfNodeDefinition {
+    NodeDefinition {
         name,
 
         mesh,
@@ -736,7 +445,7 @@ fn load_node<'a>(node: gltf::Node<'a>) -> GltfNodeDefinition {
 fn instantiate_node_hierarchy(
     factory: &mut Factory,
     gltf: &GltfDefinitions,
-    nodes: &mut HashMap<usize, GltfNode>,
+    nodes: &mut HashMap<usize, Node>,
     parent: &Group,
     node_index: usize,
 ) {
@@ -795,7 +504,7 @@ fn instantiate_node_hierarchy(
         instantiate_node_hierarchy(factory, gltf, nodes, &group, child_index);
     }
 
-    let instance = GltfNode {
+    let instance = Node {
         group,
         meshes,
         skeleton: None,
@@ -867,7 +576,7 @@ impl super::Factory {
         &mut self,
         definitions: &GltfDefinitions,
         scene: usize,
-    ) -> GltfScene {
+    ) -> Hierarchy {
         // Get the scene definition.
         //
         // NOTE: We use `get` here (instead of indexing into the scenes list normally) so that
@@ -926,7 +635,7 @@ impl super::Factory {
             }
         }
 
-        GltfScene {
+        Hierarchy {
             group,
             nodes,
             roots,
@@ -939,7 +648,7 @@ impl super::Factory {
     /// animation references a node that is not in `scene`, then `Err(())` is returned.
     pub fn instantiate_gltf_animation(
         &mut self,
-        scene: &GltfScene,
+        scene: &Hierarchy,
         anim_def: &GltfAnimationDefinition,
     ) -> Result<Clip, ()> {
         // Apply each track in the animation definition to its target node in the scene.

--- a/src/factory/load_gltf.rs
+++ b/src/factory/load_gltf.rs
@@ -99,8 +99,11 @@ pub struct GltfDefinitions {
     /// The scene nodes loaded from the glTF file.
     pub nodes: Vec<GltfNodeDefinition>,
 
-    /// The scenes described from the glTF file.
+    /// The scenes described in the glTF file.
     pub scenes: Vec<GltfSceneDefinition>,
+
+    /// The skinned skeltons loaded from the glTF file.
+    pub skins: Vec<GltfSkinDefinition>,
 }
 
 /// A template for a glTF mesh instance.
@@ -193,6 +196,29 @@ pub struct GltfSceneDefinition {
     ///
     /// These indices correspond to elements in the
     pub roots: Vec<usize>,
+}
+
+/// The definition for a skeleton used for vertex skinning in a glTF file.
+///
+/// When instantiated, this corresponds to a [`Skeleton`].
+#[derive(Debug, Clone)]
+pub struct GltfSkinDefinition {
+    /// The bones composing the skeleton.
+    pub bones: Vec<GltfBoneDefinition>,
+}
+
+/// The definition for a bone in a [`GltfSkinDefinition`].
+///
+/// When instantiated, this corresponds to a [`Bone`].
+#[derive(Debug, Clone)]
+pub struct GltfBoneDefinition {
+    /// The inverse bind matrix used to transform the mesh for this bone's joint.
+    pub inverse_bind_matrix: mint::ColumnMatrix4<f32>,
+
+    /// The index of the node that acts as the joint for this bone.
+    ///
+    /// This index corresponds to a node in the `nodes` list of the parent [`GltfDefinitions`].
+    pub joint: usize,
 }
 
 fn build_scene_hierarchy(

--- a/src/factory/mod.rs
+++ b/src/factory/mod.rs
@@ -1027,7 +1027,14 @@ impl Factory {
             instantiate_hierarchy(&mut *hub, &mut self.backend, hierarchy, &group, &mut nodes, root_index);
         }
 
-        unimplemented!("Finish instantiating hierarchy")
+        Hierarchy {
+            group,
+            roots: hierarchy.roots.clone(),
+            nodes,
+
+            // TODO: Instantiate the animations.
+            animations: Vec::new(),
+        }
     }
 }
 

--- a/src/factory/mod.rs
+++ b/src/factory/mod.rs
@@ -16,11 +16,7 @@ use image;
 use itertools::Either;
 use mint;
 use obj;
-#[cfg(feature = "gltf-loader")]
-use vec_map::VecMap;
 
-#[cfg(feature = "gltf-loader")]
-use animation::Clip;
 use audio;
 use camera::{Camera, Projection, ZRange};
 use color::{BLACK, Color};
@@ -40,6 +36,9 @@ use sprite::Sprite;
 use skeleton::{Bone, Skeleton};
 use text::{Font, Text, TextData};
 use texture::{CubeMap, CubeMapPath, FilterMethod, Sampler, Texture, WrapMode};
+
+#[cfg(feature = "gltf-loader")]
+pub use self::load_gltf::*;
 
 const TANGENT_X: [I8Norm; 4] = [I8Norm(1), I8Norm(0), I8Norm(0), I8Norm(1)];
 const NORMAL_Z: [I8Norm; 4] = [I8Norm(0), I8Norm(0), I8Norm(1), I8Norm(0)];
@@ -78,60 +77,6 @@ pub struct Factory {
     texture_cache: HashMap<PathBuf, Texture<[f32; 4]>>,
     default_sampler: gfx::handle::Sampler<BackendResources>,
 }
-
-/// Loaded glTF 2.0 returned by [`Factory::load_gltf`].
-///
-/// [`Factory::load_gltf`]: struct.Factory.html#method.load_gltf
-#[cfg(feature = "gltf-loader")]
-#[derive(Debug, Clone)]
-pub struct Gltf {
-    /// Imported camera views.
-    pub cameras: Vec<Camera>,
-
-    /// Imported animation clips.
-    pub clips: Vec<Clip>,
-
-    /// The node heirarchy of the default scene.
-    ///
-    /// If the `glTF` contained no default scene then this
-    /// container will be empty.
-    pub heirarchy: VecMap<object::Group>,
-
-    /// Imported mesh instances.
-    ///
-    /// ### Notes
-    ///
-    /// * Must be kept alive in order to be displayed.
-    pub instances: Vec<Mesh>,
-
-    /// Imported mesh materials.
-    pub materials: Vec<Material>,
-
-    /// Imported mesh templates.
-    pub meshes: VecMap<Vec<Mesh>>,
-
-    /// The root node of the default scene.
-    ///
-    /// If the `glTF` contained no default scene then this group
-    /// will have no children.
-    pub root: object::Group,
-
-    /// Imported skeletons.
-    pub skeletons: Vec<Skeleton>,
-
-    /// Imported textures.
-    pub textures: Vec<Texture<[f32; 4]>>,
-}
-
-#[cfg(feature = "gltf-loader")]
-impl AsRef<object::Base> for Gltf {
-    fn as_ref(&self) -> &object::Base {
-        self.root.as_ref()
-    }
-}
-
-#[cfg(feature = "gltf-loader")]
-impl object::Object for Gltf {}
 
 fn f2i(x: f32) -> I8Norm {
     I8Norm(cmp::min(cmp::max((x * 127.0) as isize, -128), 127) as i8)

--- a/src/factory/mod.rs
+++ b/src/factory/mod.rs
@@ -1020,6 +1020,12 @@ impl Factory {
     pub fn instantiate_hierarchy(&mut self, hierarchy: &Hierarchy) -> Hierarchy {
         let mut hub = self.hub.lock().unwrap();
 
+        // Make sure all nodes are up-to-date by processing any pending messages. This is
+        // mostly relevant for cases where the user tries to instantiate the hierarchy on the same
+        // frame that the original was created, in which case the messages setting up the
+        // original will need to be processed before creating the new instance.
+        hub.process_messages();
+
         let group = Group::new(&mut *hub);
 
         let mut nodes = HashMap::with_capacity(hierarchy.nodes.len());

--- a/src/factory/mod.rs
+++ b/src/factory/mod.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "gltf-loader")]
-mod load_gltf;
+pub(crate) mod load_gltf;
 
 use std::{cmp, fs, io, iter, ops};
 use std::borrow::Cow;
@@ -36,9 +36,6 @@ use sprite::Sprite;
 use skeleton::{Bone, Skeleton};
 use text::{Font, Text, TextData};
 use texture::{CubeMap, CubeMapPath, FilterMethod, Sampler, Texture, WrapMode};
-
-#[cfg(feature = "gltf-loader")]
-pub use self::load_gltf::*;
 
 const TANGENT_X: [I8Norm; 4] = [I8Norm(1), I8Norm(0), I8Norm(0), I8Norm(1)];
 const NORMAL_Z: [I8Norm; 4] = [I8Norm(0), I8Norm(0), I8Norm(1), I8Norm(0)];
@@ -156,6 +153,19 @@ impl Factory {
         let data = hub::SkeletonData { bones, gpu_buffer, gpu_buffer_view };
         let object = self.hub.lock().unwrap().spawn_skeleton(data);
         Skeleton { object }
+    }
+
+    /// Create a new camera using the provided projection.
+    ///
+    /// This allows you to create a camera from a predefined projection, which is useful if you
+    /// e.g. load projection data from a file and don't necessarily know ahead of time what type
+    /// of projection the camera uses. If you're manually creating a camera, you should use
+    /// [`perspective_camera`] or [`orthographic_camera`].
+    pub fn camera<P: Into<Projection>>(&mut self, projection: P) -> Camera {
+        Camera::new(
+            &mut *self.hub.lock().unwrap(),
+            projection.into(),
+        )
     }
 
     /// Create new [Orthographic] Camera.

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -124,12 +124,9 @@ impl Hub {
         Arc::new(Mutex::new(hub))
     }
 
-    pub(crate) fn spawn(
-        &mut self,
-        sub: SubNode,
-    ) -> Base {
+    pub(crate) fn spawn(&mut self, node: NodeInternal) -> Base {
         Base {
-            node: self.nodes.create(sub.into()),
+            node: self.nodes.create(node),
             tx: self.message_tx.clone(),
         }
     }
@@ -140,21 +137,21 @@ impl Hub {
         gpu_data: GpuData,
         skeleton: Option<Skeleton>,
     ) -> Base {
-        self.spawn(SubNode::Visual(mat, gpu_data, skeleton))
+        self.spawn(SubNode::Visual(mat, gpu_data, skeleton).into())
     }
 
     pub(crate) fn spawn_light(
         &mut self,
         data: LightData,
     ) -> Base {
-        self.spawn(SubNode::Light(data))
+        self.spawn(SubNode::Light(data).into())
     }
 
     pub(crate) fn spawn_skeleton(
         &mut self,
         data: SkeletonData,
     ) -> Base {
-        self.spawn(SubNode::Skeleton(data))
+        self.spawn(SubNode::Skeleton(data).into())
     }
 
     pub(crate) fn process_messages(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,6 +363,9 @@ pub use scene::{Background, Scene};
 pub use sprite::Sprite;
 
 #[doc(inline)]
+pub use template::{Hierarchy, HierarchyNode};
+
+#[doc(inline)]
 pub use text::{Align, Font, Layout, Text};
 
 #[doc(inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,6 +307,7 @@ pub mod render;
 pub mod scene;
 pub mod skeleton;
 mod sprite;
+mod template;
 mod text;
 mod texture;
 mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,7 +328,7 @@ pub use factory::Factory;
 
 #[cfg(feature = "gltf-loader")]
 #[doc(inline)]
-pub use factory::Gltf;
+pub use factory::load_gltf::*;
 
 #[doc(inline)]
 pub use geometry::{Geometry, Joints, Shape};

--- a/src/node.rs
+++ b/src/node.rs
@@ -42,6 +42,16 @@ impl NodeInternal {
             _space: PhantomData,
         }
     }
+
+    pub(crate) fn shallow_clone(&self, sub: SubNode) -> NodeInternal {
+        NodeInternal {
+            visible: true,
+            transform: self.transform,
+            world_transform: cgmath::Transform::one(),
+            next_sibling: None,
+            sub_node: sub,
+        }
+    }
 }
 
 impl From<SubNode> for NodeInternal {

--- a/src/object.rs
+++ b/src/object.rs
@@ -173,7 +173,7 @@ impl Object for Base {}
 /// as with a single entity.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Group {
-    object: Base,
+    pub(crate) object: Base,
 }
 three_object!(Group::object);
 
@@ -181,7 +181,7 @@ impl Group {
     pub(crate) fn new(hub: &mut Hub) -> Self {
         let sub = SubNode::Group { first_child: None };
         Group {
-            object: hub.spawn(sub),
+            object: hub.spawn(sub.into()),
         }
     }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,0 +1,301 @@
+use mint;
+use std::collections::HashMap;
+
+use camera::{Camera, Projection};
+use skeleton::Skeleton;
+
+use animation::Track;
+use {Group, Material, Mesh, Texture};
+use geometry::Geometry;
+use object;
+
+/// A glTF scene that has been instantiated and can be added to a [`Scene`].
+///
+/// Created by instantiating a scene defined in a [`GltfDefinitions`] with
+/// [`Factory::instantiate_gltf_scene`]. A `Hierarchy` can be added to a [`Scene`] with
+/// [`Scene::add`].
+///
+/// # Examples
+///
+/// ```no_run
+/// # let mut window = three::Window::new("three-rs");
+/// let definitions = window.factory.load_gltf("my_data.gltf");
+///
+/// let gltf_scene = window.factory.instantiate_gltf_scene(&definitions, 0);
+/// window.scene.add(&gltf_scene);
+/// ```
+///
+/// [`Scene`]: struct.Scene.html
+/// [`Scene::add`]: struct.Scene.html#method.add
+/// [`GltfDefinitions`]: struct.GltfDefinitions.html
+/// [`Factory::instantiate_gltf_scene`]: struct.Factory.html#method.instantiate_gltf_scene
+#[derive(Debug, Clone)]
+pub struct Hierarchy {
+    /// A group containing all of the root nodes of the scene.
+    ///
+    /// While the glTF format allows scenes to have an arbitrary number of root nodes, all scene
+    /// roots are added to a single root group to make it easier to manipulate the scene as a
+    /// whole. See [`roots`] for the full list of root nodes for the scene.
+    ///
+    /// [`roots`]: #structfield.roots
+    pub group: object::Group,
+
+    /// The indices of the root nodes of the scene.
+    ///
+    /// Each index corresponds to a node in [`nodes`].
+    ///
+    /// [`nodes`]: #structfield.nodes
+    pub roots: Vec<usize>,
+
+    /// The nodes that are part of the scene.
+    ///
+    /// Node instances are stored in a [`HashMap`] where the key is the node's index in the source
+    /// [`GltfDefinitions::nodes`]. Note that a [`HashMap`] is used instead of a [`Vec`] because
+    /// not all nodes in the source file are guaranteed to be used in the scene, and so node
+    /// indices in the scene instance may not be contiguous.
+    ///
+    /// [`HashMap`]: https://doc.rust-lang.org/stable/std/collections/struct.HashMap.html
+    /// [`Vec`]: https://doc.rust-lang.org/stable/std/vec/struct.Vec.html
+    /// [`GltfDefinitions::nodes`]: struct.GltfDefinitions.html#structfield.nodes
+    pub nodes: HashMap<usize, Node>,
+}
+
+impl Hierarchy {
+    /// Finds the first node in the scene with the specified name, using a [`GltfDefinitions`]
+    /// to lookup the name for each node.
+    ///
+    /// Name matching is case-sensitive. Returns the first node with a matching name, otherwise
+    /// returns `None`.
+    pub fn find_node_by_name(
+        &self,
+        name: &str,
+        definitions: &GltfDefinitions,
+    ) -> Option<&Node> {
+        for (index, node) in &self.nodes {
+            if let Some(node_def) = definitions.nodes.get(*index) {
+                if node_def.name.as_ref().map(|node_name| node_name == name).unwrap_or(false) {
+                    return Some(node);
+                }
+            }
+        }
+
+        None
+    }
+}
+
+impl AsRef<object::Base> for Hierarchy {
+    fn as_ref(&self) -> &object::Base {
+        self.group.as_ref()
+    }
+}
+
+impl object::Object for Hierarchy {}
+
+/// A node in a scene from a glTF file that has been instantiated.
+#[derive(Debug, Clone)]
+pub struct Node {
+    /// The group that represents this node.
+    pub group: Group,
+
+    /// The meshes associated with this node.
+    pub meshes: Vec<Mesh>,
+
+    /// The skeleton associated with this node.
+    ///
+    /// If `skeleton` has a value, then there will be at least one mesh in `meshes`.
+    pub skeleton: Option<Skeleton>,
+
+    /// The camera associated with this node.
+    pub camera: Option<Camera>,
+
+    /// The indices of the children of this node.
+    pub children: Vec<usize>,
+}
+
+impl AsRef<object::Base> for Node {
+    fn as_ref(&self) -> &object::Base {
+        self.group.as_ref()
+    }
+}
+
+impl object::Object for Node {}
+
+/// Raw data loaded from a glTF file with [`Factory::load_gltf`].
+///
+/// This is the raw data used as a template to instantiate three objects in the scene. Entire
+/// glTF scenes can be instantiated using [`Factory::instantiate_gltf_scene`].
+///
+/// [`Factory::load_gltf`]: struct.Factory.html#method.load_gltf
+#[derive(Debug, Clone)]
+pub struct GltfDefinitions {
+    /// The materials loaded from the glTF file.
+    pub materials: Vec<Material>,
+
+    /// The camera projections defined in the glTF file.
+    pub cameras: Vec<Projection>,
+
+    /// The meshes loaded from the glTF file.
+    pub meshes: Vec<GltfMeshDefinition>,
+
+    /// The scene nodes loaded from the glTF file.
+    pub nodes: Vec<NodeDefinition>,
+
+    /// The scenes described in the glTF file.
+    pub scenes: Vec<HierarchyDefinition>,
+
+    /// The index of the default scene, if specified by the glTF file.
+    ///
+    /// The index corresponds to an element in `scenes`.
+    pub default_scene: Option<usize>,
+
+    /// The skinned skeltons loaded from the glTF file.
+    pub skins: Vec<GltfSkinDefinition>,
+
+    /// The animation clips loaded from the glTF file.
+    pub animations: Vec<GltfAnimationDefinition>,
+
+    /// Imported textures.
+    pub textures: Vec<Texture<[f32; 4]>>,
+}
+
+/// A template for a glTF mesh instance.
+///
+/// Note that a glTF mesh doesn't map directly to three's [`Mesh`] type (see
+/// [`GltfPrimitiveDefinition`] for a more direct analogy). Rather, `GltfMeshDefinition` can
+/// be instantated into a [`Group`] with one or more [`Mesh`] instances added to the group.
+///
+/// [`Mesh`]: struct.Mesh.html
+/// [`GltfPrimitiveDefinition`]: struct.GltfPrimitiveDefinition.html
+/// [`Group`]: struct.Group.html
+#[derive(Debug, Clone)]
+pub struct GltfMeshDefinition {
+    /// The name of the mesh template.
+    pub name: Option<String>,
+
+    /// The primitives included in the mesh template.
+    ///
+    /// When the mesh template is instantiated, each primitive is instantiated as a [`Mesh`].
+    pub primitives: Vec<GltfPrimitiveDefinition>,
+}
+
+/// A template for a glTF mesh primitive.
+///
+/// A `GltfPrimitiveDefinition` can be converted directly into a [`Mesh`] using [`Factory::mesh`]. Note that
+/// to do this, the material must first be retrieved by index from the parent [`GltfDefinitions`].
+#[derive(Debug, Clone)]
+pub struct GltfPrimitiveDefinition {
+    /// The geometric data described by this primitive.
+    pub geometry: Geometry,
+
+    /// The index of the material associated with this mesh primitive, if any.
+    ///
+    /// The index can be used to lookup the material data from the `materials` map of the parent
+    /// [`GltfDefinitions`].
+    ///
+    /// If no material is specified, then the glTF default material (an unlit, flat black material)
+    /// will be used when instantiating the primitive.
+    pub material: Option<usize>,
+}
+
+/// The definition of a node used in a glTF file.
+///
+/// Nodes are composed to create a graph of elements in a glTF scene.
+#[derive(Debug, Clone)]
+pub struct NodeDefinition {
+    /// The name of the node.
+    pub name: Option<String>,
+
+    /// The index of the mesh associated with this node, if any.
+    ///
+    /// The index can be used to lookup the associated mesh definition in the `meshes` map of the
+    /// parent [`GltfDefinitions`].
+    pub mesh: Option<usize>,
+
+    /// The index of the camera associated with this node, if any.
+    ///
+    /// The index can be used to lookup the associated camera projection in the `cameras` map of
+    /// the parent [`GltfDefinitions`].
+    pub camera: Option<usize>,
+
+    /// The index of the skin attached to this node, if any.
+    ///
+    /// The index corresponds to a skin in the `skins` list of the parent [`GltfDefinitions`].
+    ///
+    /// Note that if `skin` has a value, then `mesh` will also have a value.
+    pub skin: Option<usize>,
+
+    /// The indices of this node's children. A node may have zero or more children.
+    ///
+    /// Each index corresponds to a node in the `nodes` map of the parent [`GltfDefinitions`].
+    pub children: Vec<usize>,
+
+    /// The node's local translation.
+    ///
+    /// This translation is relative to its parent node when instantiated.
+    pub translation: mint::Point3<f32>,
+
+    /// The node's local orientation.
+    ///
+    /// This rotation is relative to its parent node when instantiated.
+    pub rotation: mint::Quaternion<f32>,
+
+    /// The node's local scale.
+    ///
+    /// This scale is relative to its parent node when instantiated.
+    pub scale: f32,
+}
+
+/// The definition of a scene from a glTF file.
+///
+/// A glTF scene is a hierarchy of nodes, begining with one or more root nodes. Note that glTF
+/// scenes are *not* the same as three [`Scene`]s, and must be explicity added to a [`Scene`]
+/// when instantiated.
+#[derive(Debug, Clone)]
+pub struct HierarchyDefinition {
+    /// The name of the scene.
+    pub name: Option<String>,
+
+    /// The indices of the root nodes of the scene.
+    ///
+    /// These indices correspond to elements in the
+    pub roots: Vec<usize>,
+}
+
+/// The definition for a skeleton used for vertex skinning in a glTF file.
+///
+/// When instantiated, this corresponds to a [`Skeleton`].
+#[derive(Debug, Clone)]
+pub struct GltfSkinDefinition {
+    /// The bones composing the skeleton.
+    pub bones: Vec<GltfBoneDefinition>,
+}
+
+/// The definition for a bone in a [`GltfSkinDefinition`].
+///
+/// When instantiated, this corresponds to a [`Bone`].
+#[derive(Debug, Clone)]
+pub struct GltfBoneDefinition {
+    /// The inverse bind matrix used to transform the mesh for this bone's joint.
+    pub inverse_bind_matrix: mint::ColumnMatrix4<f32>,
+
+    /// The index of the node that acts as the joint for this bone.
+    ///
+    /// This index corresponds to a node in the `nodes` list of the parent [`GltfDefinitions`].
+    pub joint: usize,
+}
+
+/// The definition for an animation in a glTF file.
+///
+/// When instantiated, this corresponds to a [`Clip`].
+#[derive(Debug, Clone)]
+pub struct GltfAnimationDefinition {
+    /// The name of the animation.
+    pub name: Option<String>,
+
+    /// The tracks making up the animation.
+    ///
+    /// Each track is composed of a [`Track`] containing the data for the track, and an index
+    /// of the node that the track targets. The node is an index into the `nodes` list of the
+    /// parent [`GltfDefinitions`].
+    pub tracks: Vec<(Track, usize)>,
+}

--- a/src/template.rs
+++ b/src/template.rs
@@ -56,6 +56,7 @@ pub struct Hierarchy {
     /// [`GltfDefinitions::nodes`]: struct.GltfDefinitions.html#structfield.nodes
     pub nodes: HashMap<usize, HierarchyNode>,
 
+    /// Animations tied to this hierarchy.
     pub animations: Vec<animation::Clip>,
 }
 
@@ -65,7 +66,7 @@ impl Hierarchy {
     ///
     /// Name matching is case-sensitive. Returns the first node with a matching name, otherwise
     /// returns `None`.
-    pub fn find_node_by_name(
+    pub fn find_by_name(
         &self,
         name: &str,
     ) -> Option<&HierarchyNode> {
@@ -86,6 +87,9 @@ impl object::Object for Hierarchy {}
 /// A node in a scene from a glTF file that has been instantiated.
 #[derive(Debug, Clone)]
 pub struct HierarchyNode {
+    /// The name of the node.
+    ///
+    /// Names are not guaranteed to be unique, but can be used to help identify nodes.
     pub name: Option<String>,
 
     /// The group that represents this node.

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,13 +1,10 @@
-use mint;
 use std::collections::HashMap;
 
-use camera::{Camera, Projection};
-use skeleton::Skeleton;
-
-use animation::Track;
-use {Group, Material, Mesh, Texture};
-use geometry::Geometry;
+use {Group, Mesh};
+use animation;
+use camera::Camera;
 use object;
+use skeleton::Skeleton;
 
 /// A glTF scene that has been instantiated and can be added to a [`Scene`].
 ///
@@ -57,7 +54,9 @@ pub struct Hierarchy {
     /// [`HashMap`]: https://doc.rust-lang.org/stable/std/collections/struct.HashMap.html
     /// [`Vec`]: https://doc.rust-lang.org/stable/std/vec/struct.Vec.html
     /// [`GltfDefinitions::nodes`]: struct.GltfDefinitions.html#structfield.nodes
-    pub nodes: HashMap<usize, Node>,
+    pub nodes: HashMap<usize, HierarchyNode>,
+
+    pub animations: Vec<animation::Clip>,
 }
 
 impl Hierarchy {
@@ -69,17 +68,10 @@ impl Hierarchy {
     pub fn find_node_by_name(
         &self,
         name: &str,
-        definitions: &GltfDefinitions,
-    ) -> Option<&Node> {
-        for (index, node) in &self.nodes {
-            if let Some(node_def) = definitions.nodes.get(*index) {
-                if node_def.name.as_ref().map(|node_name| node_name == name).unwrap_or(false) {
-                    return Some(node);
-                }
-            }
-        }
-
-        None
+    ) -> Option<&HierarchyNode> {
+        self.nodes
+            .values()
+            .find(|node| node.name.as_ref().map(|n| n == name).unwrap_or(false))
     }
 }
 
@@ -93,7 +85,9 @@ impl object::Object for Hierarchy {}
 
 /// A node in a scene from a glTF file that has been instantiated.
 #[derive(Debug, Clone)]
-pub struct Node {
+pub struct HierarchyNode {
+    pub name: Option<String>,
+
     /// The group that represents this node.
     pub group: Group,
 
@@ -112,190 +106,10 @@ pub struct Node {
     pub children: Vec<usize>,
 }
 
-impl AsRef<object::Base> for Node {
+impl AsRef<object::Base> for HierarchyNode {
     fn as_ref(&self) -> &object::Base {
         self.group.as_ref()
     }
 }
 
-impl object::Object for Node {}
-
-/// Raw data loaded from a glTF file with [`Factory::load_gltf`].
-///
-/// This is the raw data used as a template to instantiate three objects in the scene. Entire
-/// glTF scenes can be instantiated using [`Factory::instantiate_gltf_scene`].
-///
-/// [`Factory::load_gltf`]: struct.Factory.html#method.load_gltf
-#[derive(Debug, Clone)]
-pub struct GltfDefinitions {
-    /// The materials loaded from the glTF file.
-    pub materials: Vec<Material>,
-
-    /// The camera projections defined in the glTF file.
-    pub cameras: Vec<Projection>,
-
-    /// The meshes loaded from the glTF file.
-    pub meshes: Vec<GltfMeshDefinition>,
-
-    /// The scene nodes loaded from the glTF file.
-    pub nodes: Vec<NodeDefinition>,
-
-    /// The scenes described in the glTF file.
-    pub scenes: Vec<HierarchyDefinition>,
-
-    /// The index of the default scene, if specified by the glTF file.
-    ///
-    /// The index corresponds to an element in `scenes`.
-    pub default_scene: Option<usize>,
-
-    /// The skinned skeltons loaded from the glTF file.
-    pub skins: Vec<GltfSkinDefinition>,
-
-    /// The animation clips loaded from the glTF file.
-    pub animations: Vec<GltfAnimationDefinition>,
-
-    /// Imported textures.
-    pub textures: Vec<Texture<[f32; 4]>>,
-}
-
-/// A template for a glTF mesh instance.
-///
-/// Note that a glTF mesh doesn't map directly to three's [`Mesh`] type (see
-/// [`GltfPrimitiveDefinition`] for a more direct analogy). Rather, `GltfMeshDefinition` can
-/// be instantated into a [`Group`] with one or more [`Mesh`] instances added to the group.
-///
-/// [`Mesh`]: struct.Mesh.html
-/// [`GltfPrimitiveDefinition`]: struct.GltfPrimitiveDefinition.html
-/// [`Group`]: struct.Group.html
-#[derive(Debug, Clone)]
-pub struct GltfMeshDefinition {
-    /// The name of the mesh template.
-    pub name: Option<String>,
-
-    /// The primitives included in the mesh template.
-    ///
-    /// When the mesh template is instantiated, each primitive is instantiated as a [`Mesh`].
-    pub primitives: Vec<GltfPrimitiveDefinition>,
-}
-
-/// A template for a glTF mesh primitive.
-///
-/// A `GltfPrimitiveDefinition` can be converted directly into a [`Mesh`] using [`Factory::mesh`]. Note that
-/// to do this, the material must first be retrieved by index from the parent [`GltfDefinitions`].
-#[derive(Debug, Clone)]
-pub struct GltfPrimitiveDefinition {
-    /// The geometric data described by this primitive.
-    pub geometry: Geometry,
-
-    /// The index of the material associated with this mesh primitive, if any.
-    ///
-    /// The index can be used to lookup the material data from the `materials` map of the parent
-    /// [`GltfDefinitions`].
-    ///
-    /// If no material is specified, then the glTF default material (an unlit, flat black material)
-    /// will be used when instantiating the primitive.
-    pub material: Option<usize>,
-}
-
-/// The definition of a node used in a glTF file.
-///
-/// Nodes are composed to create a graph of elements in a glTF scene.
-#[derive(Debug, Clone)]
-pub struct NodeDefinition {
-    /// The name of the node.
-    pub name: Option<String>,
-
-    /// The index of the mesh associated with this node, if any.
-    ///
-    /// The index can be used to lookup the associated mesh definition in the `meshes` map of the
-    /// parent [`GltfDefinitions`].
-    pub mesh: Option<usize>,
-
-    /// The index of the camera associated with this node, if any.
-    ///
-    /// The index can be used to lookup the associated camera projection in the `cameras` map of
-    /// the parent [`GltfDefinitions`].
-    pub camera: Option<usize>,
-
-    /// The index of the skin attached to this node, if any.
-    ///
-    /// The index corresponds to a skin in the `skins` list of the parent [`GltfDefinitions`].
-    ///
-    /// Note that if `skin` has a value, then `mesh` will also have a value.
-    pub skin: Option<usize>,
-
-    /// The indices of this node's children. A node may have zero or more children.
-    ///
-    /// Each index corresponds to a node in the `nodes` map of the parent [`GltfDefinitions`].
-    pub children: Vec<usize>,
-
-    /// The node's local translation.
-    ///
-    /// This translation is relative to its parent node when instantiated.
-    pub translation: mint::Point3<f32>,
-
-    /// The node's local orientation.
-    ///
-    /// This rotation is relative to its parent node when instantiated.
-    pub rotation: mint::Quaternion<f32>,
-
-    /// The node's local scale.
-    ///
-    /// This scale is relative to its parent node when instantiated.
-    pub scale: f32,
-}
-
-/// The definition of a scene from a glTF file.
-///
-/// A glTF scene is a hierarchy of nodes, begining with one or more root nodes. Note that glTF
-/// scenes are *not* the same as three [`Scene`]s, and must be explicity added to a [`Scene`]
-/// when instantiated.
-#[derive(Debug, Clone)]
-pub struct HierarchyDefinition {
-    /// The name of the scene.
-    pub name: Option<String>,
-
-    /// The indices of the root nodes of the scene.
-    ///
-    /// These indices correspond to elements in the
-    pub roots: Vec<usize>,
-}
-
-/// The definition for a skeleton used for vertex skinning in a glTF file.
-///
-/// When instantiated, this corresponds to a [`Skeleton`].
-#[derive(Debug, Clone)]
-pub struct GltfSkinDefinition {
-    /// The bones composing the skeleton.
-    pub bones: Vec<GltfBoneDefinition>,
-}
-
-/// The definition for a bone in a [`GltfSkinDefinition`].
-///
-/// When instantiated, this corresponds to a [`Bone`].
-#[derive(Debug, Clone)]
-pub struct GltfBoneDefinition {
-    /// The inverse bind matrix used to transform the mesh for this bone's joint.
-    pub inverse_bind_matrix: mint::ColumnMatrix4<f32>,
-
-    /// The index of the node that acts as the joint for this bone.
-    ///
-    /// This index corresponds to a node in the `nodes` list of the parent [`GltfDefinitions`].
-    pub joint: usize,
-}
-
-/// The definition for an animation in a glTF file.
-///
-/// When instantiated, this corresponds to a [`Clip`].
-#[derive(Debug, Clone)]
-pub struct GltfAnimationDefinition {
-    /// The name of the animation.
-    pub name: Option<String>,
-
-    /// The tracks making up the animation.
-    ///
-    /// Each track is composed of a [`Track`] containing the data for the track, and an index
-    /// of the node that the track targets. The node is an index into the `nodes` list of the
-    /// parent [`GltfDefinitions`].
-    pub tracks: Vec<(Track, usize)>,
-}
+impl object::Object for HierarchyNode {}


### PR DESCRIPTION
> NOTE: This PR is not yet ready to merge, but I would like to get feedback on the overall direction of this approach while I'm finishing the final details.

This is a follow-up to #197 that adds a more general-purpose system for instantiating copies of entire node hierarchies. The new API includes a `Hierarchy` type that contains all of the objects and describes the hierarchy of nodes, and a method `Factory::instantiate_hierarchy` to duplicate an existing hierarchy. `Factory::load_gltf` has been updated to return a `Vec<Hierarchy>`, with one `Hierarchy` for each scene described in the file. While `load_gltf` is currently the only way to easily construct a `Hierarchy`, the system is meant to be independent of glTF functionality and extra utilities could be added to make it easier for users to construct their own `Hierarchy` objects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/three-rs/three/199)
<!-- Reviewable:end -->
