### PR TITLE
Add node names

### DIFF
--- a/src/hub.rs
+++ b/src/hub.rs
@@ -88,6 +88,7 @@ pub(crate) enum Operation {
     SetShadow(ShadowMap, ShadowProjection),
     SetTexelRange(mint::Point2<i16>, mint::Vector2<u16>),
     SetWeights(Vec<f32>),
+    SetName(String),
 }
 
 pub(crate) type HubPtr = Arc<Mutex<Hub>>;
@@ -297,6 +298,9 @@ impl Hub {
                         }
                         x = self.nodes[&ptr].next_sibling.clone();
                     }
+                }
+                Operation::SetName(name) => {
+                    self.nodes[&ptr].name = Some(name);
                 }
             }
         }

--- a/src/node.rs
+++ b/src/node.rs
@@ -20,12 +20,22 @@ pub(crate) type TransformInternal = cgmath::Decomposed<cgmath::Vector3<f32>, cgm
 pub(crate) struct NodeInternal {
     /// `true` if this node (and its children) are visible to cameras.
     pub(crate) visible: bool,
+
+    /// A user-defined name for the node.
+    ///
+    /// Not used internally to implement functionality. This is used by users to identify nodes
+    /// programatically, and to act as a utility when debugging.
+    pub(crate) name: Option<String>,
+
     /// The transform relative to the node's parent.
     pub(crate) transform: TransformInternal,
+
     /// The transform relative to the scene root.
     pub(crate) world_transform: TransformInternal,
+
     /// Pointer to the next sibling.
     pub(crate) next_sibling: Option<NodePointer>,
+
     /// Context specific-data, for example, `UiText`, `Visual` or `Light`.
     pub(crate) sub_node: SubNode,
 }
@@ -35,6 +45,7 @@ impl NodeInternal {
         Node {
             transform: self.transform.into(),
             visible: self.visible,
+            name: self.name.clone(),
             material: match self.sub_node {
                 SubNode::Visual(ref mat, _, _) => Some(mat.clone()),
                 _ => None,
@@ -48,6 +59,7 @@ impl From<SubNode> for NodeInternal {
     fn from(sub: SubNode) -> Self {
         NodeInternal {
             visible: true,
+            name: None,
             transform: cgmath::Transform::one(),
             world_transform: cgmath::Transform::one(),
             next_sibling: None,
@@ -83,16 +95,22 @@ pub enum Local {}
 /// World space, defined relative to the scene root.
 pub enum World {}
 
-/// General information about scene `Node`.
+/// General information about an object in a scene.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Node<Space> {
     /// Is `Node` visible by cameras or not?
     pub visible: bool,
-    //Note: this really begs for `euclid`-style parametrized math types.
+
+    /// The name of the node, if any.
+    pub name: Option<String>,
+
     /// Transformation in `Space`.
+    // NOTE: this really begs for `euclid`-style parametrized math types.
     pub transform: Transform,
+
     /// Material in case this `Node` has it.
     pub material: Option<Material>,
+
     ///
     pub(crate) _space: PhantomData<Space>,
 }

--- a/src/object.rs
+++ b/src/object.rs
@@ -45,6 +45,14 @@ pub trait Object: AsRef<Base> {
         self.as_ref().send(Operation::SetVisible(visible));
     }
 
+    /// Sets the name of the object.
+    fn set_name<S: Into<String>>(
+        &self,
+        name: S,
+    ) {
+        self.as_ref().send(Operation::SetName(name.into()));
+    }
+
     /// Set both position, orientation and scale.
     fn set_transform<P, Q>(
         &self,

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -186,6 +186,7 @@ impl<'a> SyncGuard<'a> {
             .expect("Unable to find objects for world resolve!");
         node::Node {
             visible: wn.world_visible,
+            name: wn.node.name.clone(),
             transform: wn.world_transform.into(),
             material: match wn.node.sub_node {
                 SubNode::Visual(ref mat, _, _) => Some(mat.clone()),


### PR DESCRIPTION
This PR adds the ability to set the name of `Object` types, and retrieve those names when using `SyncGuard` to query the current state of an object.

* Add new member `name: Option<String>` to `NodeInternal` and `Node`.
* Add new trait method `Object::set_name` to allow users to set the name of an object.

This is something that has been discussed in relation to the new template functionality I'm adding in #203. In discussing it with @kvark, he stated that he'd like nodes to be named directly, rather than attempting to have to look up nodes based on their names in a template.