### PR TITLE
Resolve internal object data with SyncGuard

### DIFF
--- a/examples/gltf-pbr-shader.rs
+++ b/examples/gltf-pbr-shader.rs
@@ -1,6 +1,9 @@
 extern crate three;
 
-use three::Object;
+use three::{
+    camera::Camera,
+    Object,
+};
 
 fn main() {
     let mut win = three::Window::new("Three-rs glTF example");
@@ -21,15 +24,12 @@ fn main() {
     let (instance, _) = win.factory.instantiate_template(&templates[0]);
     win.scene.add(&instance);
 
-    // TODO: Look for an existing camera within the glTF scene. We'll need the ability to walk
-    // the scene hierarchy before we can do this.
-    let cam = None;
-    // for node in instance.nodes.values() {
-    //     if let Some(ref camera) = node.camera {
-    //         cam = Some(camera.clone());
-    //         break;
-    //     }
-    // }
+    // Attempt to find a camera in the instantiated template to use as the perspective for
+    // rendering.
+    let cam = {
+        let guard = win.scene.sync_guard();
+        guard.find_child_of_type::<Camera>(&instance)
+    };
 
     // If we didn't find a camera in the glTF scene, create a default one to use.
     let cam = cam.unwrap_or_else(|| {

--- a/examples/gltf-pbr-shader.rs
+++ b/examples/gltf-pbr-shader.rs
@@ -26,10 +26,10 @@ fn main() {
 
     // Attempt to find a camera in the instantiated template to use as the perspective for
     // rendering.
-    let cam = {
-        let guard = win.scene.sync_guard();
-        guard.find_child_of_type::<Camera>(&instance)
-    };
+    let cam = win
+        .scene
+        .sync_guard()
+        .find_child_of_type::<Camera>(&instance);
 
     // If we didn't find a camera in the glTF scene, create a default one to use.
     let cam = cam.unwrap_or_else(|| {

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,7 +1,7 @@
 //! Primitives for audio playback.
 
 use hub;
-use object;
+use object::{self, DowncastObject, ObjectType};
 use std::fmt;
 use std::io::Cursor;
 use std::rc::Rc;
@@ -116,6 +116,15 @@ pub struct Source {
     pub(crate) object: object::Base,
 }
 three_object!(Source::object);
+
+impl DowncastObject for Source {
+    fn downcast(object_type: ObjectType) -> Option<Self> {
+        match object_type {
+            ObjectType::AudioSource(audio_source) => Some(audio_source),
+            _ => None,
+        }
+    }
+}
 
 impl Source {
     pub(crate) fn with_object(object: object::Base) -> Self {

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,7 +1,7 @@
 //! Primitives for audio playback.
 
 use hub;
-use object::{self, DowncastObject, ObjectType};
+use object::{Base, ObjectType};
 use std::fmt;
 use std::io::Cursor;
 use std::rc::Rc;
@@ -113,21 +113,13 @@ impl AudioData {
 /// You may create several `Source`s to play sounds simultaneously.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Source {
-    pub(crate) object: object::Base,
+    pub(crate) object: Base,
 }
 three_object!(Source::object);
-
-impl DowncastObject for Source {
-    fn downcast(object_type: ObjectType) -> Option<Self> {
-        match object_type {
-            ObjectType::AudioSource(audio_source) => Some(audio_source),
-            _ => None,
-        }
-    }
-}
+derive_DowncastObject!(Source => ObjectType::AudioSource);
 
 impl Source {
-    pub(crate) fn with_object(object: object::Base) -> Self {
+    pub(crate) fn with_object(object: Base) -> Self {
         Source { object }
     }
 

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -100,27 +100,15 @@ pub enum Projection {
 /// [`Projection`]: enum.Projection.html
 #[derive(Clone, Debug, PartialEq)]
 pub struct Camera {
-    object: object::Base,
-
-    /// Projection parameters of this camera.
-    pub projection: Projection,
+    pub(crate) object: object::Base,
 }
 three_object!(Camera::object);
 
 impl Camera {
     pub(crate) fn new(hub: &mut Hub, projection: Projection) -> Self {
         Camera {
-            object: hub.spawn(SubNode::Empty),
-            projection,
+            object: hub.spawn(SubNode::Camera(projection)),
         }
-    }
-
-    /// Computes the projection matrix representing the camera's projection.
-    pub fn matrix(
-        &self,
-        aspect_ratio: f32,
-    ) -> mint::ColumnMatrix4<f32> {
-        self.projection.matrix(aspect_ratio)
     }
 }
 

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -60,7 +60,7 @@ use cgmath;
 use mint;
 
 use hub::{Hub, Operation, SubNode};
-use object::{self, DowncastObject, Object, ObjectType};
+use object::{Base, DowncastObject, Object, ObjectType};
 use scene::SyncGuard;
 
 use std::ops;
@@ -101,22 +101,20 @@ pub enum Projection {
 /// [`Projection`]: enum.Projection.html
 #[derive(Clone, Debug, PartialEq)]
 pub struct Camera {
-    pub(crate) object: object::Base,
+    pub(crate) object: Base,
 }
 
-impl AsRef<object::Base> for Camera {
-    fn as_ref(&self) -> &object::Base { &self.object }
+impl AsRef<Base> for Camera {
+    fn as_ref(&self) -> &Base { &self.object }
 }
 
 impl Object for Camera {
     type Data = Projection;
 
     fn resolve_data(&self, sync_guard: &SyncGuard) -> Self::Data {
-        let node = &sync_guard.hub[self];
-
-        match node.sub_node {
+        match &sync_guard.hub[self].sub_node {
             SubNode::Camera(ref projection) => projection.clone(),
-            _ => panic!("`Group` had a bad sub node type: {:?}", node.sub_node),
+            sub_node @ _ => panic!("`Group` had a bad sub node type: {:?}", sub_node),
         }
     }
 }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -59,7 +59,7 @@
 use cgmath;
 use mint;
 
-use hub::{Hub, SubNode};
+use hub::{Hub, Operation, SubNode};
 use object::{self, DowncastObject, Object, ObjectType};
 use scene::SyncGuard;
 
@@ -126,6 +126,11 @@ impl Camera {
         Camera {
             object: hub.spawn(SubNode::Camera(projection)),
         }
+    }
+
+    /// Sets the projection used by the camera.
+    pub fn set_projection<P: Into<Projection>>(&self, projection: P) {
+        self.as_ref().send(Operation::SetProjection(projection.into()));
     }
 }
 

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -60,7 +60,7 @@ use cgmath;
 use mint;
 
 use hub::{Hub, SubNode};
-use object;
+use object::{self, DowncastObject, ObjectType};
 
 use std::ops;
 
@@ -108,6 +108,15 @@ impl Camera {
     pub(crate) fn new(hub: &mut Hub, projection: Projection) -> Self {
         Camera {
             object: hub.spawn(SubNode::Camera(projection)),
+        }
+    }
+}
+
+impl DowncastObject for Camera {
+    fn downcast(object_type: ObjectType) -> Option<Camera> {
+        match object_type {
+            ObjectType::Camera(camera) => Some(camera),
+            _ => None,
         }
     }
 }

--- a/src/factory/load_gltf.rs
+++ b/src/factory/load_gltf.rs
@@ -481,7 +481,7 @@ fn load_node<'a>(
         cameras.push(CameraTemplate {
             object,
             projection: load_camera(camera),
-        })
+        });
     }
 
     object_index

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -374,11 +374,11 @@ impl Hub {
         walker
     }
 
-    pub(crate) fn walk(&self, base: &Option<NodePointer>) -> TreeWalker {
+    pub(crate) fn walk<'a>(&'a self, base: &Option<NodePointer>) -> TreeWalker<'a> {
         self.walk_impl(base, true)
     }
 
-    pub(crate) fn walk_all(&self, base: &Option<NodePointer>) -> TreeWalker {
+    pub(crate) fn walk_all<'a>(&'a self, base: &Option<NodePointer>) -> TreeWalker<'a> {
         self.walk_impl(base, false)
     }
 }

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -90,6 +90,7 @@ pub(crate) enum Operation {
     SetTexelRange(mint::Point2<i16>, mint::Vector2<u16>),
     SetWeights(Vec<f32>),
     SetName(String),
+    SetProjection(Projection),
 }
 
 pub(crate) type HubPtr = Arc<Mutex<Hub>>;
@@ -310,6 +311,14 @@ impl Hub {
                 }
                 Operation::SetName(name) => {
                     self.nodes[&ptr].name = Some(name);
+                }
+                Operation::SetProjection(projection) => {
+                    match self.nodes[&ptr].sub_node {
+                        SubNode::Camera(ref mut internal_projection) => {
+                            *internal_projection = projection;
+                        }
+                        _ => unreachable!()
+                    }
                 }
             }
         }

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -1,4 +1,5 @@
 use audio::{AudioData, Operation as AudioOperation};
+use camera::Projection;
 use color::{self, Color};
 use light::{ShadowMap, ShadowProjection};
 use material::Material;
@@ -51,8 +52,8 @@ pub(crate) struct VisualData {
 
 #[derive(Debug)]
 pub(crate) enum SubNode {
-    /// No extra data.
-    Empty,
+    /// Camera for rendering a scene.
+    Camera(Projection),
     /// Group can be a parent to other objects.
     Group { first_child: Option<NodePointer> },
     /// Audio data.

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -383,11 +383,11 @@ impl Hub {
         walker
     }
 
-    pub(crate) fn walk<'a>(&'a self, base: &Option<NodePointer>) -> TreeWalker<'a> {
+    pub(crate) fn walk(&self, base: &Option<NodePointer>) -> TreeWalker {
         self.walk_impl(base, true)
     }
 
-    pub(crate) fn walk_all<'a>(&'a self, base: &Option<NodePointer>) -> TreeWalker<'a> {
+    pub(crate) fn walk_all(&self, base: &Option<NodePointer>) -> TreeWalker {
         self.walk_impl(base, false)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,9 @@
 //!
 //! All three objects are marked by the [`Object`] trait which provides the
 //! library with the [`object::Base`] type. Users may implement this trait in
-//! order to add their own structs into the scene heirarchy.
+//! order to add their own structs into the scene heirarchy. Three-rs provides a helper
+//! macro [`three_object`] which provides a convenient way to implement [`Object`] for your
+//! types:
 //!
 //! ```rust,no_run
 //! #[macro_use]
@@ -183,14 +185,7 @@
 //!     group: three::Group,
 //! }
 //!
-//! impl AsRef<three::object::Base> for MyObject {
-//!     fn as_ref(&self) -> &three::object::Base {
-//!         self.group.as_ref()
-//!     }
-//! }
-//!
-//!
-//! impl Object for MyObject {}
+//! three_object!(MyObject::group);
 //!
 //! fn main() {
 //! #    let mut window = three::Window::new("");
@@ -245,6 +240,7 @@
 //! [`Renderer`]: struct.Renderer.html
 //! [`Scene`]: scene/struct.Scene.html
 //! [`Window`]: window/struct.Window.html
+//! [`three_object`]: macro.three_object.html
 
 extern crate arrayvec;
 #[macro_use]

--- a/src/light.rs
+++ b/src/light.rs
@@ -187,6 +187,10 @@ impl Object for Point {
 derive_DowncastObject!(Point => ObjectType::PointLight);
 
 /// Internal data for [`Ambient`], [`Directional`], and [`Point`] lights.
+///
+/// [`Ambient`]: ./struct.Ambient.html
+/// [`Directional`]: ./struct.Directional.html
+/// [`Point`]: ./struct.Point.html
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LightData {
     /// The color of the light.
@@ -206,6 +210,8 @@ impl<'a> From<&'a hub::LightData> for LightData {
 }
 
 /// Internal data for [`Hemisphere`] lights.
+///
+/// [`Hemisphere`]: ./struct.Hemisphere.html
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HemisphereLightData {
     /// The ground color of the light.

--- a/src/light.rs
+++ b/src/light.rs
@@ -1,7 +1,7 @@
 //! Contains different types of light sources.
 
 use gfx;
-use object::{self, Object, ObjectType};
+use object::{Base, Object, ObjectType};
 use std::ops;
 
 use camera::Orthographic;
@@ -37,28 +37,26 @@ impl ShadowMap {
 /// all objects in the scene equally.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Ambient {
-    pub(crate) object: object::Base,
+    pub(crate) object: Base,
 }
 
 impl Ambient {
-    pub(crate) fn new(object: object::Base) -> Self {
+    pub(crate) fn new(object: Base) -> Self {
         Ambient { object }
     }
 }
 
-impl AsRef<object::Base> for Ambient {
-    fn as_ref(&self) -> &object::Base { &self.object }
+impl AsRef<Base> for Ambient {
+    fn as_ref(&self) -> &Base { &self.object }
 }
 
 impl Object for Ambient {
     type Data = LightData;
 
     fn resolve_data(&self, sync_guard: &SyncGuard) -> Self::Data {
-        let node = &sync_guard.hub[self];
-
-        match node.sub_node {
+        match &sync_guard.hub[self].sub_node {
             SubNode::Light(ref light_data) => light_data.into(),
-            _ => panic!("`Ambient` had a bad sub node type: {:?}", node.sub_node),
+            sub_node @ _ => panic!("`Ambient` had a bad sub node type: {:?}", sub_node),
         }
     }
 }
@@ -70,11 +68,11 @@ derive_DowncastObject!(Ambient => ObjectType::AmbientLight);
 /// there is shading, but cannot be any distance falloff.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Directional {
-    pub(crate) object: object::Base,
+    pub(crate) object: Base,
 }
 
 impl Directional {
-    pub(crate) fn new(object: object::Base) -> Self {
+    pub(crate) fn new(object: Base) -> Self {
         Directional {
             object,
         }
@@ -97,19 +95,17 @@ impl Directional {
     }
 }
 
-impl AsRef<object::Base> for Directional {
-    fn as_ref(&self) -> &object::Base { &self.object }
+impl AsRef<Base> for Directional {
+    fn as_ref(&self) -> &Base { &self.object }
 }
 
 impl Object for Directional {
     type Data = LightData;
 
     fn resolve_data(&self, sync_guard: &SyncGuard) -> Self::Data {
-        let node = &sync_guard.hub[self];
-
-        match node.sub_node {
+        match &sync_guard.hub[self].sub_node {
             SubNode::Light(ref light_data) => light_data.into(),
-            _ => panic!("`Directional` had a bad sub node type: {:?}", node.sub_node),
+            sub_node @ _ => panic!("`Directional` had a bad sub node type: {:?}", sub_node),
         }
     }
 }
@@ -127,28 +123,26 @@ derive_DowncastObject!(Directional => ObjectType::DirectionalLight);
 /// how much the normal is oriented to the upper and the lower hemisphere.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Hemisphere {
-    pub(crate) object: object::Base,
+    pub(crate) object: Base,
 }
 
 impl Hemisphere {
-    pub(crate) fn new(object: object::Base) -> Self {
+    pub(crate) fn new(object: Base) -> Self {
         Hemisphere { object }
     }
 }
 
-impl AsRef<object::Base> for Hemisphere {
-    fn as_ref(&self) -> &object::Base { &self.object }
+impl AsRef<Base> for Hemisphere {
+    fn as_ref(&self) -> &Base { &self.object }
 }
 
 impl Object for Hemisphere {
     type Data = HemisphereLightData;
 
     fn resolve_data(&self, sync_guard: &SyncGuard) -> Self::Data {
-        let node = &sync_guard.hub[self];
-
-        match node.sub_node {
+        match &sync_guard.hub[self].sub_node {
             SubNode::Light(ref light_data) => light_data.into(),
-            _ => panic!("`Hemisphere` had a bad sub node type: {:?}", node.sub_node),
+            sub_node @ _ => panic!("`Hemisphere` had a bad sub node type: {:?}", sub_node),
         }
     }
 }
@@ -158,28 +152,26 @@ derive_DowncastObject!(Hemisphere => ObjectType::HemisphereLight);
 /// Light originates from a single point, and spreads outward in all directions.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Point {
-    pub(crate) object: object::Base,
+    pub(crate) object: Base,
 }
 
 impl Point {
-    pub(crate) fn new(object: object::Base) -> Self {
+    pub(crate) fn new(object: Base) -> Self {
         Point { object }
     }
 }
 
-impl AsRef<object::Base> for Point {
-    fn as_ref(&self) -> &object::Base { &self.object }
+impl AsRef<Base> for Point {
+    fn as_ref(&self) -> &Base { &self.object }
 }
 
 impl Object for Point {
     type Data = LightData;
 
     fn resolve_data(&self, sync_guard: &SyncGuard) -> Self::Data {
-        let node = &sync_guard.hub[self];
-
-        match node.sub_node {
+        match &sync_guard.hub[self].sub_node {
             SubNode::Light(ref light_data) => light_data.into(),
-            _ => panic!("`Point` had a bad sub node type: {:?}", node.sub_node),
+            sub_node @ _ => panic!("`Point` had a bad sub node type: {:?}", sub_node),
         }
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -34,11 +34,12 @@
 /// ```
 ///
 /// [`object::Base`]: object/struct.Base.html
+#[macro_export]
 macro_rules! three_object {
     ($name:ident::$field:ident) => {
         impl AsRef<$crate::object::Base> for $name {
             fn as_ref(&self) -> &$crate::object::Base {
-                &self.$field
+                &self.$field.as_ref()
             }
         }
 
@@ -48,6 +49,10 @@ macro_rules! three_object {
             fn resolve_data(&self, _: & $crate::scene::SyncGuard) -> Self::Data {}
         }
     };
+
+    ($name:ident) => {
+        three_object!($name ::object);
+    }
 }
 
 macro_rules! derive_DowncastObject {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -45,7 +45,7 @@ macro_rules! three_object {
         impl $crate::Object for $name {
             type Data = ();
 
-            fn resolve_data(&self, _: &mut $crate::scene::SyncGuard) -> Self::Data {}
+            fn resolve_data(&self, _: & $crate::scene::SyncGuard) -> Self::Data {}
         }
     };
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -42,6 +42,10 @@ macro_rules! three_object {
             }
         }
 
-        impl $crate::Object for $name {}
+        impl $crate::Object for $name {
+            type Data = ();
+
+            fn resolve_data(&self, _: &mut $crate::scene::SyncGuard) -> Self::Data {}
+        }
     };
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -49,3 +49,16 @@ macro_rules! three_object {
         }
     };
 }
+
+macro_rules! derive_DowncastObject {
+    ($type:ident => $pattern:path) => {
+        impl ::object::DowncastObject for $type {
+            fn downcast(object: ::object::ObjectType) -> Option<Self> {
+                match object {
+                    $pattern (inner) => Some(inner),
+                    _ => None,
+                }
+            }
+        }
+    }
+}

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -1,8 +1,7 @@
-use object;
-
 use geometry::Geometry;
 use hub::Operation;
 use material::Material;
+use object::{self, DowncastObject, ObjectType};
 use render::DynamicData;
 use skeleton::Skeleton;
 
@@ -75,6 +74,15 @@ pub struct Mesh {
     pub(crate) object: object::Base,
 }
 three_object!(Mesh::object);
+
+impl DowncastObject for Mesh {
+    fn downcast(object_type: ObjectType) -> Option<Mesh> {
+        match object_type {
+            ObjectType::Mesh(mesh) => Some(mesh),
+            _ => None,
+        }
+    }
+}
 
 /// A dynamic version of a mesh allows changing the geometry on CPU side
 /// in order to animate the mesh.

--- a/src/node.rs
+++ b/src/node.rs
@@ -7,7 +7,6 @@ use material::Material;
 
 use std::marker::PhantomData;
 
-
 /// Pointer to a Node
 pub(crate) type NodePointer = froggy::Pointer<NodeInternal>;
 pub(crate) type TransformInternal = cgmath::Decomposed<cgmath::Vector3<f32>, cgmath::Quaternion<f32>>;

--- a/src/node.rs
+++ b/src/node.rs
@@ -115,8 +115,11 @@ impl From<TransformInternal> for Transform {
 }
 
 /// Local space, defined relative to the parent node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Local {}
+
 /// World space, defined relative to the scene root.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum World {}
 
 /// General information about an object in a scene.

--- a/src/object.rs
+++ b/src/object.rs
@@ -209,9 +209,7 @@ impl Object for Base {
     type Data = ObjectType;
 
     fn resolve_data(&self, sync_guard: &SyncGuard) -> Self::Data {
-        let node = &sync_guard.hub[self];
-        match &node.sub_node {
-            // TODO: Handle resolving cameras better (`Empty` is only used for cameras).
+        match &sync_guard.hub[self].sub_node {
             SubNode::Camera(..) => ObjectType::Camera(Camera {
                 object: self.clone(),
             }),
@@ -340,11 +338,9 @@ impl Object for Group {
 
     fn resolve_data(&self, sync_guard: &SyncGuard) -> Vec<Base> {
         let mut children = Vec::new();
-        let node = &sync_guard.hub[self];
-
-        let mut child = match node.sub_node {
+        let mut child = match &sync_guard.hub[self].sub_node {
             SubNode::Group { ref first_child } => first_child.clone(),
-            _ => panic!("`Group` had a bad sub node type: {:?}", node.sub_node),
+            sub_node @ _ => panic!("`Group` had a bad sub node type: {:?}", sub_node),
         };
 
         while let Some(child_pointer) = child {

--- a/src/object.rs
+++ b/src/object.rs
@@ -314,7 +314,7 @@ pub enum ObjectType {
 ///
 /// [`Base`]: ./struct.Base.html
 /// [`SyncGuard::downcast`]: ../scene/struct.SyncGuard.html#method.downcast
-pub trait DowncastObject: Sized {
+pub trait DowncastObject: Object + Sized {
     /// Attempts to extract the concrete type of the object from an [`ObjectType`].
     ///
     /// Prefer to use [`SyncGuard::downcast`] over calling this directly.

--- a/src/object.rs
+++ b/src/object.rs
@@ -7,6 +7,7 @@ use std::sync::mpsc;
 use mint;
 
 use audio;
+use camera::Camera;
 use hub::{Hub, Message, Operation, SubLight, SubNode};
 use light;
 use mesh::Mesh;
@@ -207,7 +208,9 @@ impl Object for Base {
         let node = &sync_guard.hub[self];
         match &node.sub_node {
             // TODO: Handle resolving cameras better (`Empty` is only used for cameras).
-            SubNode::Empty => unimplemented!("Cameras need to be changed my dude"),
+            SubNode::Camera(..) => ObjectType::Camera(Camera {
+                object: self.clone(),
+            }),
 
             SubNode::Group { .. } => ObjectType::Group(Group {
                 object: self.clone(),
@@ -293,6 +296,9 @@ pub enum ObjectType {
 
     /// A UI text object.
     Text(Text),
+
+    /// A camera.
+    Camera(Camera),
 }
 
 /// Marks an object type that can be downcast from a [`Base`].

--- a/src/object.rs
+++ b/src/object.rs
@@ -50,11 +50,15 @@ pub trait Object: AsRef<Base> {
     /// Each object type has its own internal data, and not all object types can provide access
     /// to meaningful data. Types that cannot provide user-facing data will specify `()`
     /// for `Data`.
+    ///
+    /// [`SyncGuard::resolve_data`]: ./scene/struct.SyncGuard.html#method.resolve_data
     type Data;
 
     /// Retrieves the internal data for the object.
     ///
     /// Prefer to use [`SyncGuard::resolve_data`] over calling this directly.
+    ///
+    /// [`SyncGuard::resolve_data`]: ./scene/struct.SyncGuard.html#method.resolve_data
     fn resolve_data(&self, sync_guard: &SyncGuard) -> Self::Data;
 
     /// Converts into the base type.
@@ -260,8 +264,11 @@ impl Object for Base {
 
 /// The possible concrete types that a [`Base`] can be resolved to.
 ///
-/// When using [`SyncGuard::resolve_data`] with a [`Base`], it will resolve to the concrete
-/// object type that the base represents.
+/// When using [`SyncGuard::resolve_data`] with a [`Base`], it returns an `ObjectType`
+/// containing the concrete object for the [`Base`].
+///
+/// [`Base`]: ./struct.Base.html
+/// [`SyncGuard::resolve_data`]: ../scene/struct.SyncGuard.html#method.resolve_data
 #[derive(Debug, Clone)]
 pub enum ObjectType {
     /// An audio source.
@@ -302,10 +309,18 @@ pub enum ObjectType {
 }
 
 /// Marks an object type that can be downcast from a [`Base`].
+///
+/// See [`SyncGuard::downcast`] for information on how this trait is used.
+///
+/// [`Base`]: ./struct.Base.html
+/// [`SyncGuard::downcast`]: ../scene/struct.SyncGuard.html#method.downcast
 pub trait DowncastObject: Sized {
     /// Attempts to extract the concrete type of the object from an [`ObjectType`].
     ///
     /// Prefer to use [`SyncGuard::downcast`] over calling this directly.
+    ///
+    /// [`ObjectType`]: ./enum.ObjectType.html
+    /// [`SyncGuard::downcast`]: ../scene/struct.SyncGuard.html#method.downcast
     fn downcast(object: ObjectType) -> Option<Self>;
 }
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -55,7 +55,7 @@ pub trait Object: AsRef<Base> {
     /// Retrieves the internal data for the object.
     ///
     /// Prefer to use [`SyncGuard::resolve_data`] over calling this directly.
-    fn resolve_data(&self, sync_guard: &mut SyncGuard) -> Self::Data;
+    fn resolve_data(&self, sync_guard: &SyncGuard) -> Self::Data;
 
     /// Converts into the base type.
     fn upcast(&self) -> Base {
@@ -204,7 +204,7 @@ impl AsRef<Base> for Base {
 impl Object for Base {
     type Data = ObjectType;
 
-    fn resolve_data(&self, sync_guard: &mut SyncGuard) -> Self::Data {
+    fn resolve_data(&self, sync_guard: &SyncGuard) -> Self::Data {
         let node = &sync_guard.hub[self];
         match &node.sub_node {
             // TODO: Handle resolving cameras better (`Empty` is only used for cameras).
@@ -324,7 +324,7 @@ impl AsRef<Base> for Group {
 impl Object for Group {
     type Data = Vec<Base>;
 
-    fn resolve_data(&self, sync_guard: &mut SyncGuard) -> Vec<Base> {
+    fn resolve_data(&self, sync_guard: &SyncGuard) -> Vec<Base> {
         let mut children = Vec::new();
         let node = &sync_guard.hub[self];
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -263,6 +263,7 @@ impl Object for Base {
 ///
 /// When using [`SyncGuard::resolve_data`] with a [`Base`], it will resolve to the concrete
 /// object type that the base represents.
+#[derive(Debug, Clone)]
 pub enum ObjectType {
     /// An audio source.
     AudioSource(audio::Source),

--- a/src/object.rs
+++ b/src/object.rs
@@ -53,7 +53,7 @@ pub trait Object: AsRef<Base> {
 
     /// Retrieves the internal data for the object.
     ///
-    /// Prefer to use [`SyncGuard::resolve_data`] instead.
+    /// Prefer to use [`SyncGuard::resolve_data`] over calling this directly.
     fn resolve_data(&self, sync_guard: &mut SyncGuard) -> Self::Data;
 
     /// Converts into the base type.
@@ -295,6 +295,14 @@ pub enum ObjectType {
     Text(Text),
 }
 
+/// Marks an object type that can be downcast from a [`Base`].
+pub trait DowncastObject: Sized {
+    /// Attempts to extract the concrete type of the object from an [`ObjectType`].
+    ///
+    /// Prefer to use [`SyncGuard::downcast`] over calling this directly.
+    fn downcast(object: ObjectType) -> Option<Self>;
+}
+
 /// Groups are used to combine several other objects or groups to work with them
 /// as with a single entity.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -328,6 +336,15 @@ impl Object for Group {
         }
 
         children
+    }
+}
+
+impl DowncastObject for Group {
+    fn downcast(object: ObjectType) -> Option<Self> {
+        match object {
+            ObjectType::Group(group) => Some(group),
+            _ => None,
+        }
     }
 }
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -244,7 +244,6 @@ impl Object for Base {
 
                 SubLight::Directional => ObjectType::DirectionalLight(light::Directional {
                     object: self.clone(),
-                    shadow: light.shadow.as_ref().map(|&(ref map, _)| map.clone()),
                 }),
 
                 SubLight::Point => ObjectType::PointLight(light::Point {
@@ -346,14 +345,7 @@ impl Object for Group {
     }
 }
 
-impl DowncastObject for Group {
-    fn downcast(object: ObjectType) -> Option<Self> {
-        match object {
-            ObjectType::Group(group) => Some(group),
-            _ => None,
-        }
-    }
-}
+derive_DowncastObject!(Group => ObjectType::Group);
 
 impl Group {
     pub(crate) fn new(hub: &mut Hub) -> Self {

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -894,7 +894,11 @@ impl Renderer {
 
         // prepare target and globals
         let mx_view = Matrix4::from(mx_camera_transform.inverse_transform().unwrap());
-        let mx_proj = Matrix4::from(camera.matrix(self.aspect_ratio()));
+        let projection = match hub[&camera].sub_node {
+            SubNode::Camera(projection) => projection,
+            _ => panic!("Camera had incorrect sub node")
+        };
+        let mx_proj = Matrix4::from(projection.matrix(self.aspect_ratio()));
         self.encoder.update_constant_buffer(
             &self.const_buf,
             &Globals {

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -895,7 +895,7 @@ impl Renderer {
         // prepare target and globals
         let mx_view = Matrix4::from(mx_camera_transform.inverse_transform().unwrap());
         let projection = match hub[&camera].sub_node {
-            SubNode::Camera(projection) => projection,
+            SubNode::Camera(ref projection) => projection.clone(),
             _ => panic!("Camera had incorrect sub node")
         };
         let mx_proj = Matrix4::from(projection.matrix(self.aspect_ratio()));

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -108,6 +108,7 @@ impl Scene {
 /// walk through every enemy in your game:
 ///
 /// ```rust,no_run
+/// # #[macro_use]
 /// # extern crate three;
 /// # #[derive(Clone)]
 /// # struct Enemy {
@@ -115,13 +116,7 @@ impl Scene {
 /// #     is_visible: bool,
 /// # }
 /// #
-/// # impl three::Object for Enemy {}
-/// #
-/// # impl AsRef<three::object::Base> for Enemy {
-/// #     fn as_ref(&self) -> &three::object::Base {
-/// #         self.mesh.as_ref()
-/// #     }
-/// # }
+/// # three_object!(Enemy::mesh);
 /// #
 /// # fn main() {
 /// # use three::Object;

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -172,7 +172,7 @@ impl<'a> SyncGuard<'a> {
     /// *Note*: this can be slow.
     ///
     /// # Panics
-    /// Panics if the doesn't have this `object::Base`.
+    /// Panics if the scene doesn't have this `object::Base`.
     ///
     /// [`Node`]: ../node/struct.Node.html
     pub fn resolve_world<T: 'a + Object>(
@@ -256,8 +256,7 @@ impl<'a> SyncGuard<'a> {
     /// Performs a depth-first search starting with `root` looking for an object with `name`.
     /// Returns the [`Base`] for the first object found with a matching name, otherwise returns
     /// `None` if no such object is found. Note that if more than one such object exists in the
-    /// hierarchy, then only the first one discovered will be returned. Note, also, that if
-    /// `root` matches `name`, it will be returned.
+    /// hierarchy, then only the first one discovered will be returned.
     ///
     /// [`Base`]: ../object/struct.Base.html
     pub fn find_child_by_name(&self, root: &Group, name: &str) -> Option<Base> {
@@ -272,8 +271,9 @@ impl<'a> SyncGuard<'a> {
     /// Returns an iterator of all objects under `root` with the specified name.
     ///
     /// Performs a depth-first search starting with `root`, yielding each object in the hierarchy
-    /// matching `name`. Note that if `root` matches `name`, then it will be the first object
-    /// yielded by the iterator.
+    /// matching `name`.
+    ///
+    /// [`Group`]: ../struct.Group.html
     pub fn find_children_by_name(
         &'a self,
         root: &Group,
@@ -299,13 +299,23 @@ impl<'a> SyncGuard<'a> {
     ///
     /// Performs a depth-first search starting with `root`, recusively descending into any
     /// [`Group`] objects found. Returns the first object of type `T` encountered in the
-    /// hierarchy. Note that if `T` is `Group`, then `root` will be returned.
+    /// hierarchy.
+    ///
+    /// [`Group`]: ../struct.Group.html
     pub fn find_child_of_type<T: DowncastObject>(&'a self, root: &Group) -> Option<T> {
         self.find_children_of_type::<T>(root).next()
     }
 
-    /// Returns an iterator yielding all children of `root` of type `T`.
-    pub fn find_children_of_type<T: DowncastObject>(&'a self, root: &Group) -> impl Iterator<Item = T> + 'a {
+    /// Returns an iterator yielding all objects in the hierarchy of `root` of type `T`.
+    ///
+    /// Performs a depth-first search starting with `root`, recursively descending into any
+    /// [`Group`] objects found, yielding each object of type `T` found in the hierarchy.
+    ///
+    /// [`Group`]: ../struct.Group.html
+    pub fn find_children_of_type<T: DowncastObject>(
+        &'a self,
+        root: &Group,
+    ) -> impl Iterator<Item = T> + 'a {
         let root = root.as_ref().node.clone();
         let guard = &*self;
         self
@@ -335,6 +345,8 @@ impl<'a> SyncGuard<'a> {
     /// Performs a depth-first search starting with `root`, recursively searching [`Group`]
     /// objects, yielding any objects of `T` that match `name`. Note that if `T` is [`Group`]
     /// and `root` matches `name`, then it will be the first object yielded by the iterator.
+    ///
+    /// [`Group`]: ../struct.Group.html
     pub fn find_children_of_type_by_name<T: DowncastObject>(
         &'a self,
         root: &Group,
@@ -350,6 +362,8 @@ impl<'a> SyncGuard<'a> {
     ///
     /// If the downcast succeeds, the concrete object is returned. Returns `None` if the
     /// downcast fails.
+    ///
+    /// [`Base`]: ../object/struct.Base.html
     pub fn downcast<T: DowncastObject>(&self, base: &Base) -> Option<T> {
         let object_type = self.resolve_data(base);
         T::downcast(object_type)

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -150,8 +150,8 @@ impl Scene {
 ///
 /// [`object::Base::sync`]: ../object/struct.Base.html#method.sync
 pub struct SyncGuard<'a> {
-    scene: &'a Scene,
-    hub: MutexGuard<'a, Hub>,
+    pub(crate) scene: &'a Scene,
+    pub(crate) hub: MutexGuard<'a, Hub>,
 }
 
 impl<'a> SyncGuard<'a> {
@@ -194,6 +194,23 @@ impl<'a> SyncGuard<'a> {
             },
             _space: PhantomData,
         }
+    }
+
+    /// Obtains `object`'s internal data.
+    ///
+    /// Three-rs objects normally expose a write-only interface, making it possible to change
+    /// an object's internal values but not possible to read those values. `SyncGuard` allows
+    /// for that data to be read in a controlled way.
+    ///
+    /// Each object type has its own internal data, and not all object types can provide access
+    /// to meaningful data. The following types provide specific data you can use:
+    ///
+    /// * [`Base`]:
+    pub fn resolve_data<T: 'a + Object>(
+        &mut self,
+        object: &T,
+    ) -> T::Data {
+        object.resolve_data(self)
     }
 }
 

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -255,12 +255,7 @@ impl<'a> SyncGuard<'a> {
     ///
     /// [`Base`]: ../object/struct.Base.html
     pub fn find_child_by_name(&self, root: &Group, name: &str) -> Option<Base> {
-        let root = root.as_ref().node.clone();
-        self
-            .hub
-            .walk_all(&Some(root))
-            .find(|walked| walked.node.name.as_ref().map(|node_name| node_name == name).unwrap_or(false))
-            .map(|walked| self.hub.upgrade_ptr(walked.node_ptr.clone()))
+        self.find_children_by_name(root, name).next()
     }
 
     /// Returns an iterator of all objects under `root` with the specified name.

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -3,7 +3,7 @@
 use node;
 use color::Color;
 use hub::{Hub, HubPtr, SubNode};
-use object::{Base, Object};
+use object::{Base, Group, Object};
 use texture::{CubeMap, Texture};
 
 use std::mem;
@@ -211,6 +211,21 @@ impl<'a> SyncGuard<'a> {
         object: &T,
     ) -> T::Data {
         object.resolve_data(self)
+    }
+
+    /// Finds a node in a group, or any of its children, by name.
+    ///
+    /// Performs a depth-first search starting with `root` looking for an object with `name`.
+    /// Returns the [`Base`] for the first object found with a matching name, otherwise returns
+    /// `None` if no such object is found. Note that if more than one object exists in the
+    /// hierarchy, then only the first one discovered will be returned.
+    pub fn find_child(&mut self, root: &Group, name: &str) -> Option<Base> {
+        let root = root.as_ref().node.clone();
+        self
+            .hub
+            .walk_all(&Some(root))
+            .find(|walked| walked.node.name.as_ref().map(|node_name| node_name == name).unwrap_or(false))
+            .map(|walked| self.hub.upgrade_ptr(walked.node_ptr.clone()))
     }
 }
 

--- a/src/skeleton.rs
+++ b/src/skeleton.rs
@@ -1,7 +1,7 @@
 //! Mesh skinning.
 
 use mint;
-use object;
+use object::{self, ObjectType};
 
 /// Contains array of bones.
 #[derive(Clone, Debug)]
@@ -9,6 +9,7 @@ pub struct Skeleton {
     pub(crate) object: object::Base,
 }
 three_object!(Skeleton::object);
+derive_DowncastObject!(Skeleton => ObjectType::Skeleton);
 
 /// A single bone that forms one component of a [`Skeleton`].
 ///
@@ -18,6 +19,7 @@ pub struct Bone {
     pub(crate) object: object::Base,
 }
 three_object!(Bone::object);
+derive_DowncastObject!(Bone => ObjectType::Bone);
 
 /// A matrix defining how bind mesh nodes to a bone.
 pub type InverseBindMatrix = mint::ColumnMatrix4<f32>;

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -8,6 +8,7 @@ pub struct Sprite {
     pub(crate) object: object::Base,
 }
 three_object!(Sprite::object);
+derive_DowncastObject!(Sprite => object::ObjectType::Sprite);
 
 impl Sprite {
     pub(crate) fn new(object: object::Base) -> Self {

--- a/src/text.rs
+++ b/src/text.rs
@@ -171,6 +171,7 @@ pub struct Text {
     pub(crate) object: object::Base,
 }
 three_object!(Text::object);
+derive_DowncastObject!(Text => object::ObjectType::Text);
 
 impl Text {
     pub(crate) fn with_object(object: object::Base) -> Self {


### PR DESCRIPTION
This PR increases the utility of `SyncGuard` by increasing the information that it can be used to retrieve. In addition to retrieving the `Node` data for any object, it is now possible to:

* Downcast a `Base` to its concrete object type.
* Retrieve internal state data for various object types (e.g. the list of children for `Group`, the projection for `Camera`, etc.).
* Walk the hierarchy of objects under a `Group`.
* Search the hierarchy of objects under a `Group` for specific objects based on their name or type.

This functionality is especially important in conjunction with the `Template` functionality added in #203, as this now allows users to retrieve the objects in a template instance, which drastically increases the utility of templates to create re-usable object hierarchies.

# Changes

* Adds a new trait `DowncastObject`, which marks object types that can be downcast from `Base`.
  * This is done as a new trait (instead of adding the functionality to `Object`) so that it could be implemented for all type *but* `Base`. This makes attempting to downcast to `Base` a compile error, since doing so is a meaningless operation.
  * Implements `DowncastObject` for all existing `Object` types in three-rs.
* Adds `Data` type member to `Object`, and adds new trait method `resolve_data` which allows an object to retrieve its internal data using a `SyncGuard`.
* Updates the `three_object!` macro to specify `type Data = ()` and provide a basic implementation for `resolve_data`.
* Adds a macro `derive_DowncastObject!`, which provides a shorthand for implementing `DowncastObject` for internal types.
* Adds `ObjectType` enum, which represents all of the possible concrete objects types that a `Base` can be downcast to.
* Adds the following new methods to `SyncGuard`:
  * `resolve_data`
  * `walk_hierarchy`
  * `find_child_by_name`
  * `find_children_by_name`
  * `find_child_of_type`
  * `find_children_of_type`
  * `find_child_of_type_by_name`
  * `find_children_of_type_by_name`
  * `downcast`
* Removes `Camera::projection` and replace `SubNode::Empty` with `SubNode::Camera(Projection)`. Moving the projection data for a camera into the `Hub` ensures that there is a single, canonical projection for the `Camera`, even if there are multiple (or zero) concrete instances of the camera in existence (i.e. the camera was a added to a group/scene and then dropped).
* Adds `Camera::set_projection` to allow users to update a camera's projection.
* Adds functionality to `WalkedNode` and `TreeWalker` to keep track of the `NodePointer` for each node, allowing us to reconstruct the `Base` object for walked nodes.
* Removes `Directional::shadow`, since it was already duplicating the internal shadow data tracked in the `Hub`.
* Adds new structs `LightData`, for retrieving the internal data for `Point`, `Ambient`, and `Directional`; And `HemisphereLightData`, for retrieving the internal data for `Hemisphere`.
* Marks `three_object!` with `#[macro_export]` and adds support for the default variant described in its documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/three-rs/three/205)
<!-- Reviewable:end -->
