### PR TITLE
Preserve existing scale in Object::look_at

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -156,7 +156,8 @@ pub trait Object: AsRef<Base> {
             None => Vector3::unit_y(),
         };
         let q = Quaternion::look_at(dir, up).invert();
-        self.set_transform(p[0], q, 1.0);
+
+        self.as_ref().send(Operation::SetTransform(Some(p[0]), Some(q.into()), None));
     }
 }
 


### PR DESCRIPTION
`Object::look_at` resets the scale of the object to 1. This PR makes it not do that.

This can be demonstrated with a small snippet: https://gist.github.com/LPGhatguy/dc9b4323b3ce7ca950ae936b95038acd

With the correct behavior, the sphere should fill the screen vertically. In 0.3.1 as well as the current master, however, the sphere's scale is reset to 1.0 and no longer fills the screen after `look_at`.