### PR TITLE
Make audio support optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ notifications:
     on_start: never
 
 script:
-  - cargo test
+  - cargo test --no-default-features --features opengl
   - cargo test --all-features
   - cargo doc
 # - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then (cargo bench); fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,9 @@ exclude = ["doc/*", "bors.toml", ".travis.yml", "test_data/*"]
 [lib]
 
 [features]
-default = ["opengl"]
+default = ["opengl", "audio"]
 opengl = ["gfx_device_gl", "gfx_window_glutin", "glutin"]
+audio = ["rodio"]
 
 [build-dependencies]
 includedir_codegen = "0.5"
@@ -38,7 +39,7 @@ log = "0.4"
 obj = { version = "0.9", features = ["genmesh"] }
 phf = "0.7.12"
 quick-error = "1.2"
-rodio = "0.8"
+rodio = { version = "0.8", optional = true }
 mint = "0.5"
 vec_map = "0.8"
 

--- a/src/factory/mod.rs
+++ b/src/factory/mod.rs
@@ -915,7 +915,6 @@ impl Factory {
         depth_state: gfx::state::Depth,
         stencil_state: gfx::state::Stencil,
     ) -> Result<BasicPipelineState, PipelineCreationError> {
-        use gfx::traits::FactoryExt;
         let vs = Source::user(&dir, name, "vs")?;
         let ps = Source::user(&dir, name, "ps")?;
         let shaders = self.backend
@@ -994,7 +993,6 @@ impl Factory {
         &mut self,
         file_path: P,
     ) -> Font {
-        use self::io::Read;
         let file_path = file_path.as_ref();
         let mut buffer = Vec::new();
         let file = fs::File::open(&file_path).expect(&format!(

--- a/src/factory/mod.rs
+++ b/src/factory/mod.rs
@@ -18,8 +18,10 @@ use itertools::Either;
 use mint;
 use obj;
 
-use animation;
+#[cfg(feature = "audio")]
 use audio;
+
+use animation;
 use camera::{Camera, Projection, ZRange};
 use color::{BLACK, Color};
 use geometry::Geometry;
@@ -939,6 +941,7 @@ impl Factory {
         Text::with_object(object)
     }
 
+    #[cfg(feature = "audio")]
     /// Create new audio source.
     pub fn audio_source(&mut self) -> audio::Source {
         let sub = SubNode::Audio(audio::AudioData::new());
@@ -1317,6 +1320,7 @@ impl Factory {
         (groups, meshes)
     }
 
+    #[cfg(feature = "audio")]
     /// Load audio from file. Supported formats are Flac, Vorbis and WAV.
     pub fn load_audio<P: AsRef<Path>>(
         &self,

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "audio")]
 use audio::{AudioData, Operation as AudioOperation};
+
 use camera::Projection;
 use color::{self, Color};
 use light::{LightOperation, ShadowMap, ShadowProjection};
@@ -56,6 +58,7 @@ pub(crate) enum SubNode {
     Camera(Projection),
     /// Group can be a parent to other objects.
     Group { first_child: Option<NodePointer> },
+    #[cfg(feature = "audio")]
     /// Audio data.
     Audio(AudioData),
     /// Renderable text for 2D user interface.
@@ -76,6 +79,7 @@ pub(crate) type Message = (froggy::WeakPointer<NodeInternal>, Operation);
 pub(crate) enum Operation {
     AddChild(NodePointer),
     RemoveChild(NodePointer),
+    #[cfg(feature = "audio")]
     SetAudio(AudioOperation),
     SetVisible(bool),
     SetLight(LightOperation),
@@ -176,6 +180,7 @@ impl Hub {
                 Err(_) => continue,
             };
             match operation {
+                #[cfg(feature = "audio")]
                 Operation::SetAudio(operation) => {
                     if let SubNode::Audio(ref mut data) = self.nodes[&ptr].sub_node {
                         Hub::process_audio(operation, data);
@@ -335,6 +340,7 @@ impl Hub {
         self.nodes.sync_pending();
     }
 
+    #[cfg(feature = "audio")]
     fn process_audio(
         operation: AudioOperation,
         data: &mut AudioData,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,6 +266,7 @@ extern crate obj;
 extern crate phf;
 #[macro_use]
 extern crate quick_error;
+#[cfg(feature = "audio")]
 extern crate rodio;
 extern crate vec_map;
 
@@ -279,7 +280,9 @@ extern crate glutin;
 #[macro_use]
 mod macros;
 
+#[cfg(feature = "audio")]
 pub mod audio;
+
 pub mod animation;
 pub mod camera;
 pub mod color;

--- a/src/object.rs
+++ b/src/object.rs
@@ -6,7 +6,9 @@ use std::sync::mpsc;
 
 use mint;
 
+#[cfg(feature = "audio")]
 use audio;
+
 use camera::Camera;
 use hub::{Hub, Message, Operation, SubLight, SubNode};
 use light;
@@ -219,6 +221,7 @@ impl Object for Base {
                 object: self.clone(),
             }),
 
+            #[cfg(feature = "audio")]
             SubNode::Audio(..) => ObjectType::AudioSource(audio::Source {
                 object: self.clone(),
             }),
@@ -270,6 +273,7 @@ impl Object for Base {
 /// [`SyncGuard::resolve_data`]: ../scene/struct.SyncGuard.html#method.resolve_data
 #[derive(Debug, Clone)]
 pub enum ObjectType {
+    #[cfg(feature = "audio")]
     /// An audio source.
     AudioSource(audio::Source),
 


### PR DESCRIPTION
This reduces the amount of dependencies of 16 if audio support isn’t required by the game.